### PR TITLE
Add CodeQL code scanning for Go and C

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,11 +2,12 @@ name: CodeQL
 
 on:
   push:
-    branches: [main]
+    branches: [main, master]
   pull_request:
-    branches: [main]
+    branches: [main, master]
   schedule:
     - cron: '25 5 * * 1'
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
## Summary
- Adds a `.github/workflows/codeql.yml` workflow enabling GitHub CodeQL semantic security analysis
- Targets both **Go** (ubuntu-latest, autobuild) and **C/C++** (macos-latest, manual build with `-framework GSS`)
- Triggers on push to main, PRs to main, and weekly schedule (Monday 05:25 UTC)
- Uses SHA-pinned action references consistent with existing workflows

## Test plan
- [ ] Verify the CodeQL workflow runs successfully on both Go and C/C++ matrix entries
- [ ] Confirm results appear in Security > Code scanning tab
- [ ] Review any initial findings from the C memory management patterns in `gss_darwin.c`

Closes #3

https://claude.ai/code/session_019FRUZvDK7sC1ASp3583GFr