### PR TITLE
Add GitHub Actions language to CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,6 +20,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - language: actions
+            runner: ubuntu-latest
+            build-mode: none
           - language: go
             runner: ubuntu-latest
             build-mode: autobuild


### PR DESCRIPTION
## Summary
- Extends CodeQL coverage to scan GitHub Actions workflow files for security vulnerabilities such as script injection
- Adds `actions` language with `build-mode: none` to the existing CodeQL analysis matrix

## Test plan
- [ ] Verify CodeQL workflow runs successfully for all three languages (actions, go, c-cpp)
- [ ] Review any new findings from the Actions analysis

https://claude.ai/code/session_01VvZsQP17bDiMfNi8keWTj3