### PR TITLE
Add govulncheck CI workflow for Go vulnerability scanning

### DIFF
--- a/.github/workflows/govulncheck.yml
+++ b/.github/workflows/govulncheck.yml
@@ -1,0 +1,24 @@
+name: govulncheck
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+  schedule:
+    - cron: '0 12 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: Go vulnerability check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-input: stable


### PR DESCRIPTION
## Summary

- Add `govulncheck` GitHub Actions workflow that integrates the official Go vulnerability scanner into CI
- Runs on pushes to main/master, pull requests, and weekly (Mondays at noon UTC) to catch newly disclosed CVEs
- Uses reachability analysis to report only vulnerabilities in functions the code actually calls, reducing false positives

## Test plan

- [ ] Verify govulncheck workflow triggers on this PR and passes
- [ ] Verify existing CI checks (build-and-test, golangci-lint, CodeQL) still pass
- [ ] Confirm workflow uses pinned action SHAs consistent with repo conventions

Closes #5

https://claude.ai/code/session_01PUgQoGoXNPTPUQqyKCQG92