### PR TITLE
Add actionlint CI workflow with shellcheck integration

### DIFF
--- a/.github/workflows/lint-workflows.yml
+++ b/.github/workflows/lint-workflows.yml
@@ -1,0 +1,22 @@
+name: Lint Workflows
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+permissions:
+  contents: read
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run actionlint
+        uses: raven-actions/actionlint@e01d1ea33dd6a5ed517d95b4c0c357560ac6f518 # v2.1.1
+        with:
+          shellcheck: true


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow (`lint-workflows.yml`) that runs [actionlint](https://github.com/rhysd/actionlint) with shellcheck integration to validate all workflow files
- Triggers on pushes to `main`/`master` and pull requests to those branches
- Uses `raven-actions/actionlint@v2.1.1` pinned to commit SHA for supply-chain security, consistent with all other workflows

## Test plan
- [ ] Verify the new `Lint Workflows / actionlint` check runs and passes
- [ ] Verify all existing checks (Build and Test, golangci-lint, CodeQL, govulncheck) continue to pass

Closes #7

https://claude.ai/code/session_0115dwrvP9wMiLMatvEAdpSj