### PR TITLE
Add clang-tidy and cppcheck for C code static analysis

### DIFF
--- a/.github/workflows/c-static-analysis.yml
+++ b/.github/workflows/c-static-analysis.yml
@@ -25,7 +25,7 @@ jobs:
         id: linter
         with:
           style: ''
-          tidy-checks: '-*,clang-analyzer-*,bugprone-*,performance-*,portability-*'
+          tidy-checks: '-*,clang-analyzer-*,bugprone-*,-bugprone-easily-swappable-parameters,performance-*,portability-*'
           version: '18'
           files-changed-only: false
           lines-changed-only: false


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow (`c-static-analysis.yml`) that runs **clang-tidy** and **cppcheck** on `gss_darwin.c`
- Both tools run on macOS (required for `<GSS/GSS.h>` framework headers)
- clang-tidy findings appear as PR annotations via `cpp-linter/cpp-linter-action`

## Test plan
- [ ] Verify the `clang-tidy` job runs and passes on macOS
- [ ] Verify the `cppcheck` job runs and passes on macOS
- [ ] Verify existing CI workflows (build-and-test, golangci-lint, codeql, govulncheck) still pass

Closes #9

https://claude.ai/code/session_018RkwnpBjbx1cSczNJc2A5a