### PR TITLE
Add formatters for Go and C, create CONTRIBUTING.md

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Google

--- a/.github/workflows/c-static-analysis.yml
+++ b/.github/workflows/c-static-analysis.yml
@@ -10,6 +10,15 @@ permissions:
   contents: read
 
 jobs:
+  clang-format:
+    name: clang-format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Run clang-format
+        run: clang-format --dry-run --Werror gss_darwin.c gss_darwin.h
+
   clang-tidy:
     name: clang-tidy
     runs-on: macos-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,3 +8,7 @@ linters:
     - gosec
     - misspell
     - revive
+
+formatters:
+  enable:
+    - gofmt

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,143 @@
+# Contributing
+
+## Prerequisites
+
+- [Go 1.22+](https://go.dev/dl/)
+- [clang-format](https://clang.llvm.org/docs/ClangFormat.html) (for C code
+  formatting)
+
+Optional (for running the full lint suite locally):
+
+- [golangci-lint v2](https://golangci-lint.run/welcome/install/)
+- [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2)
+- [actionlint](https://github.com/rhysd/actionlint)
+- [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) (macOS only)
+- [cppcheck](http://cppcheck.net/) (macOS only)
+
+## Building
+
+### macOS (with CGO for GSS-API support)
+
+```bash
+CGO_ENABLED=1 go build -o spnego-proxy .
+```
+
+### Linux (pure Go, gokrb5 fallback)
+
+```bash
+CGO_ENABLED=0 go build -o spnego-proxy .
+```
+
+## Testing
+
+```bash
+go test -v -count=1 ./...
+```
+
+On macOS with CGO enabled, this includes the GSS-API unit tests. On Linux
+(`CGO_ENABLED=0`), only the gokrb5 path is tested.
+
+## Formatting
+
+All code must be formatted before committing. CI will reject unformatted code.
+
+### Go formatting
+
+Go code is formatted with [gofmt](https://pkg.go.dev/cmd/gofmt) (checked via
+[golangci-lint](https://golangci-lint.run/)).
+
+```bash
+# Check for formatting issues
+gofmt -d .
+
+# Fix formatting automatically
+gofmt -w .
+```
+
+### C formatting
+
+C code follows the
+[Google C++ style](https://google.github.io/styleguide/cppguide.html), enforced
+by [clang-format](https://clang.llvm.org/docs/ClangFormat.html). The
+`.clang-format` file in the repository root configures the style.
+
+```bash
+# Check for formatting issues
+clang-format --dry-run --Werror gss_darwin.c gss_darwin.h
+
+# Fix formatting automatically
+clang-format -i gss_darwin.c gss_darwin.h
+```
+
+### Markdown formatting
+
+Markdown is checked by
+[markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2). The
+`.markdownlint-cli2.yaml` file in the repository root configures the rules.
+
+```bash
+# Check for lint issues
+npx markdownlint-cli2 "**/*.md"
+
+# Fix issues automatically (where possible)
+npx markdownlint-cli2 --fix "**/*.md"
+```
+
+## Linting
+
+### Go linting
+
+```bash
+golangci-lint run
+```
+
+This runs the linters configured in `.golangci.yml`, including `gosec`,
+`revive`, `errorlint`, and others.
+
+### C static analysis (macOS only)
+
+The C static analysis tools require the macOS GSS framework headers and must be
+run on macOS.
+
+**clang-tidy:**
+
+```bash
+SDK_PATH=$(xcrun --show-sdk-path)
+clang-tidy \
+    -checks='-*,clang-analyzer-*,bugprone-*,-bugprone-easily-swappable-parameters,performance-*,portability-*' \
+    -isystem "$SDK_PATH/usr/include" \
+    gss_darwin.c -- -DGSS_USE_APPLE_FRAMEWORK -framework GSS
+```
+
+**cppcheck:**
+
+```bash
+cppcheck \
+    --enable=all \
+    --error-exitcode=1 \
+    --suppress=missingIncludeSystem \
+    --suppress=unusedFunction \
+    gss_darwin.c
+```
+
+### Workflow linting
+
+```bash
+actionlint
+```
+
+## CI checks
+
+Pull requests run the following checks automatically:
+
+| Check | Tool | Scope |
+| --- | --- | --- |
+| Go formatting | gofmt (via golangci-lint) | `*.go` |
+| Go linting | golangci-lint v2 | `*.go` |
+| Go vulnerability scan | govulncheck | Go dependencies |
+| C formatting | clang-format (Google style) | `*.c`, `*.h` |
+| C static analysis | clang-tidy, cppcheck | `*.c` (macOS) |
+| Markdown linting | markdownlint-cli2 | `*.md` |
+| Workflow linting | actionlint | `.github/workflows/` |
+| Security analysis | CodeQL | Go, C, Actions |
+| Build + test | go build, go test | macOS (CGO) + Linux |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ CGO_ENABLED=1 go build -o spnego-proxy .
 CGO_ENABLED=0 go build -o spnego-proxy .
 ```
 
+For development setup including formatting, linting, and testing, see
+[CONTRIBUTING.md](CONTRIBUTING.md).
+
 ## Usage
 
 ### macOS (GSS-API mode — passwordless)

--- a/gss_darwin.c
+++ b/gss_darwin.c
@@ -1,107 +1,113 @@
+// clang-format off
 //go:build darwin
+// clang-format on
 
-#include <GSS/GSS.h>
-#include <string.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include "gss_darwin.h"
 
-static void format_gss_error(OM_uint32 major, OM_uint32 minor, char *buf, size_t buflen) {
-    OM_uint32 msg_ctx = 0;
-    OM_uint32 min_stat;
-    gss_buffer_desc msg_buf;
-    int first = 1;
-    size_t offset = 0;
+#include <GSS/GSS.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
-    do {
-        gss_display_status(&min_stat, major, GSS_C_GSS_CODE, GSS_C_NO_OID, &msg_ctx, &msg_buf);
-        if (!first && offset < buflen - 2) {
-            buf[offset++] = ';';
-            buf[offset++] = ' ';
-        }
-        size_t to_copy = msg_buf.length < (buflen - offset - 1) ? msg_buf.length : (buflen - offset - 1);
-        memcpy(buf + offset, msg_buf.value, to_copy);
-        offset += to_copy;
-        gss_release_buffer(&min_stat, &msg_buf);
-        first = 0;
-    } while (msg_ctx != 0 && offset < buflen - 1);
+static void format_gss_error(OM_uint32 major, OM_uint32 minor, char *buf,
+                             size_t buflen) {
+  OM_uint32 msg_ctx = 0;
+  OM_uint32 min_stat;
+  gss_buffer_desc msg_buf;
+  int first = 1;
+  size_t offset = 0;
 
-    buf[offset] = '\0';
+  do {
+    gss_display_status(&min_stat, major, GSS_C_GSS_CODE, GSS_C_NO_OID, &msg_ctx,
+                       &msg_buf);
+    if (!first && offset < buflen - 2) {
+      buf[offset++] = ';';
+      buf[offset++] = ' ';
+    }
+    size_t to_copy = msg_buf.length < (buflen - offset - 1)
+                         ? msg_buf.length
+                         : (buflen - offset - 1);
+    memcpy(buf + offset, msg_buf.value, to_copy);
+    offset += to_copy;
+    gss_release_buffer(&min_stat, &msg_buf);
+    first = 0;
+  } while (msg_ctx != 0 && offset < buflen - 1);
+
+  buf[offset] = '\0';
 }
 
 gss_token_result acquire_spnego_token(const char *spn) {
-    gss_token_result result;
-    memset(&result, 0, sizeof(result));
+  gss_token_result result;
+  memset(&result, 0, sizeof(result));
 
-    OM_uint32 major, minor;
-    gss_buffer_desc name_buf;
-    gss_name_t server_name = GSS_C_NO_NAME;
-    gss_ctx_id_t context = GSS_C_NO_CONTEXT;
-    gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
+  OM_uint32 major, minor;
+  gss_buffer_desc name_buf;
+  gss_name_t server_name = GSS_C_NO_NAME;
+  gss_ctx_id_t context = GSS_C_NO_CONTEXT;
+  gss_buffer_desc output_token = GSS_C_EMPTY_BUFFER;
 
-    // SPNEGO mechanism OID: 1.3.6.1.5.5.2
-    gss_OID_desc spnego_oid_desc = { 6, (void *)"\x2b\x06\x01\x05\x05\x02" };
-    gss_OID spnego_oid = &spnego_oid_desc;
+  // SPNEGO mechanism OID: 1.3.6.1.5.5.2
+  gss_OID_desc spnego_oid_desc = {6, (void *)"\x2b\x06\x01\x05\x05\x02"};
+  gss_OID spnego_oid = &spnego_oid_desc;
 
-    // Import server name
-    name_buf.value = (void *)spn;
-    name_buf.length = strlen(spn);
-    major = gss_import_name(&minor, &name_buf, GSS_C_NT_HOSTBASED_SERVICE, &server_name);
-    if (GSS_ERROR(major)) {
-        result.error_code = 1;
-        format_gss_error(major, minor, result.error_msg, sizeof(result.error_msg));
-        return result;
-    }
+  // Import server name
+  name_buf.value = (void *)spn;
+  name_buf.length = strlen(spn);
+  major = gss_import_name(&minor, &name_buf, GSS_C_NT_HOSTBASED_SERVICE,
+                          &server_name);
+  if (GSS_ERROR(major)) {
+    result.error_code = 1;
+    format_gss_error(major, minor, result.error_msg, sizeof(result.error_msg));
+    return result;
+  }
 
-    // Acquire SPNEGO token using default credentials from the ccache
-    major = gss_init_sec_context(
-        &minor,
-        GSS_C_NO_CREDENTIAL,       // use default creds from kinit/Keychain
-        &context,
-        server_name,
-        spnego_oid,                 // SPNEGO mechanism
-        GSS_C_MUTUAL_FLAG | GSS_C_REPLAY_FLAG,
-        0,                          // default lifetime
-        GSS_C_NO_CHANNEL_BINDINGS,
-        GSS_C_NO_BUFFER,            // no input token (first call)
-        NULL,                       // actual mech type (output)
-        &output_token,
-        NULL,                       // ret_flags
-        NULL                        // time_rec
-    );
+  // Acquire SPNEGO token using default credentials from the ccache
+  major = gss_init_sec_context(
+      &minor,
+      GSS_C_NO_CREDENTIAL,  // use default creds from kinit/Keychain
+      &context, server_name,
+      spnego_oid,  // SPNEGO mechanism
+      GSS_C_MUTUAL_FLAG | GSS_C_REPLAY_FLAG,
+      0,  // default lifetime
+      GSS_C_NO_CHANNEL_BINDINGS,
+      GSS_C_NO_BUFFER,  // no input token (first call)
+      NULL,             // actual mech type (output)
+      &output_token,
+      NULL,  // ret_flags
+      NULL   // time_rec
+  );
 
-    if (GSS_ERROR(major)) {
-        result.error_code = 1;
-        format_gss_error(major, minor, result.error_msg, sizeof(result.error_msg));
-        gss_release_name(&minor, &server_name);
-        if (context != GSS_C_NO_CONTEXT) {
-            gss_delete_sec_context(&minor, &context, GSS_C_NO_BUFFER);
-        }
-        return result;
-    }
-
-    // Copy output token to caller-owned memory
-    if (output_token.length > 0) {
-        result.data = malloc(output_token.length);
-        if (result.data != NULL) {
-            memcpy(result.data, output_token.value, output_token.length);
-            result.length = output_token.length;
-        } else {
-            result.error_code = 1;
-            snprintf(result.error_msg, sizeof(result.error_msg), "failed to allocate memory for token");
-        }
-    }
-
-    // Cleanup GSS-API resources
-    gss_release_buffer(&minor, &output_token);
+  if (GSS_ERROR(major)) {
+    result.error_code = 1;
+    format_gss_error(major, minor, result.error_msg, sizeof(result.error_msg));
     gss_release_name(&minor, &server_name);
     if (context != GSS_C_NO_CONTEXT) {
-        gss_delete_sec_context(&minor, &context, GSS_C_NO_BUFFER);
+      gss_delete_sec_context(&minor, &context, GSS_C_NO_BUFFER);
     }
-
     return result;
+  }
+
+  // Copy output token to caller-owned memory
+  if (output_token.length > 0) {
+    result.data = malloc(output_token.length);
+    if (result.data != NULL) {
+      memcpy(result.data, output_token.value, output_token.length);
+      result.length = output_token.length;
+    } else {
+      result.error_code = 1;
+      snprintf(result.error_msg, sizeof(result.error_msg),
+               "failed to allocate memory for token");
+    }
+  }
+
+  // Cleanup GSS-API resources
+  gss_release_buffer(&minor, &output_token);
+  gss_release_name(&minor, &server_name);
+  if (context != GSS_C_NO_CONTEXT) {
+    gss_delete_sec_context(&minor, &context, GSS_C_NO_BUFFER);
+  }
+
+  return result;
 }
 
-void free_token_data(void *data) {
-    free(data);
-}
+void free_token_data(void *data) { free(data); }

--- a/gss_darwin.h
+++ b/gss_darwin.h
@@ -1,4 +1,6 @@
+// clang-format off
 //go:build darwin
+// clang-format on
 
 #ifndef GSS_DARWIN_H
 #define GSS_DARWIN_H
@@ -7,10 +9,10 @@
 
 // gss_token_result holds the output of a GSS-API token acquisition.
 typedef struct {
-    void *data;        // Token bytes (caller must free via free_token_data)
-    size_t length;     // Token length in bytes
-    int error_code;    // Non-zero on error
-    char error_msg[256];
+  void *data;      // Token bytes (caller must free via free_token_data)
+  size_t length;   // Token length in bytes
+  int error_code;  // Non-zero on error
+  char error_msg[256];
 } gss_token_result;
 
 // acquire_spnego_token acquires a SPNEGO token for the given service principal


### PR DESCRIPTION
## Summary

- Add `gofmt` formatting check via golangci-lint `formatters` section for Go code
- Add `clang-format` with Google style for C code, including a new CI job and `.clang-format` config
- Reformat existing C files (`gss_darwin.c`, `gss_darwin.h`) to conform to Google style
- Create `CONTRIBUTING.md` with instructions for building, formatting, linting, and testing locally
- Link from `README.md` to `CONTRIBUTING.md` for developer setup

## Test plan

- [ ] New `clang-format` CI job executes and passes
- [ ] Existing `golangci-lint` CI jobs pass with the new `gofmt` formatter enabled
- [ ] Existing `clang-tidy` and `cppcheck` jobs still pass after reformatting C code
- [ ] Markdown linting passes for both `README.md` and new `CONTRIBUTING.md`
- [ ] All other existing CI checks remain green

https://claude.ai/code/session_01SNHwkS9ByP6EvCuiV7LVXS