### PR TITLE
Trim trailing newline from password file to prevent KDC auth failures

### DIFF
--- a/auth_gokrb5.go
+++ b/auth_gokrb5.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net"
 	"os"
+	"strings"
 	"sync"
 
 	"github.com/jcmturner/gokrb5/v8/client"
@@ -50,7 +51,7 @@ func getPassword(passwordFile string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to read password file: %w", err)
 	}
-	return string(password), nil
+	return strings.TrimRight(string(password), "\r\n"), nil
 }
 
 // NewGokrb5TokenProvider creates a token provider using gokrb5 with password-based auth.


### PR DESCRIPTION
## Summary
- Strip trailing `\r\n` from password read via `-password-file` using `strings.TrimRight`
- Fixes opaque KDC preauthentication failures when password file contains trailing newline (e.g. created with `echo mypassword > pass.txt`)
- Makes file-based password path consistent with interactive `term.ReadPassword` which already strips newlines

## Test plan
- [ ] Verify `go build` succeeds
- [ ] Verify `go test` passes
- [ ] Manual: create password file with `echo password > file` and confirm auth succeeds

Closes #26

https://claude.ai/code/session_01FmykGycEvsVmqFhWvL9jkm