### PR TITLE
ci: skip C/C++ analysis when no C files changed

### DIFF
--- a/.github/workflows/c-static-analysis.yml
+++ b/.github/workflows/c-static-analysis.yml
@@ -3,8 +3,20 @@ name: C Static Analysis
 on:
   push:
     branches: [main, master]
+    paths:
+      - '**/*.c'
+      - '**/*.h'
+      - '**/*.cpp'
+      - '**/*.hpp'
+      - '.github/workflows/c-static-analysis.yml'
   pull_request:
     branches: [main, master]
+    paths:
+      - '**/*.c'
+      - '**/*.h'
+      - '**/*.cpp'
+      - '**/*.hpp'
+      - '.github/workflows/c-static-analysis.yml'
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       contents: read
@@ -21,14 +21,9 @@ jobs:
       matrix:
         include:
           - language: actions
-            runner: ubuntu-latest
             build-mode: none
           - language: go
-            runner: ubuntu-latest
             build-mode: autobuild
-          - language: c-cpp
-            runner: macos-latest
-            build-mode: manual
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -38,11 +33,56 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@6bc82e05fd0ea64601dd4b465378bbcf57de0314 # v4.32.1
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  check-c-changes:
+    name: Check C/C++ changes
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          fetch-depth: 0
+
+      - name: Check for C/C++ file changes
+        id: check
+        run: |
+          if git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" | grep -qE '\.(c|h|cpp|hpp|cc|cxx)$'; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  analyze-c-cpp:
+    name: Analyze (c-cpp)
+    needs: check-c-changes
+    if: >-
+      github.event_name != 'pull_request' ||
+      needs.check-c-changes.outputs.changed == 'true'
+    runs-on: macos-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@6bc82e05fd0ea64601dd4b465378bbcf57de0314 # v4.32.1
+        with:
+          languages: c-cpp
+          build-mode: manual
+
       - name: Build C code (macOS)
-        if: matrix.build-mode == 'manual'
         run: clang -c -DGSS_USE_APPLE_FRAMEWORK -framework GSS gss_darwin.c -o gss_darwin.o
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@6bc82e05fd0ea64601dd4b465378bbcf57de0314 # v4.32.1
         with:
-          category: "/language:${{ matrix.language }}"
+          category: "/language:c-cpp"


### PR DESCRIPTION
## Summary
- **c-static-analysis.yml**: Added `paths` filters so the workflow only triggers when C/C++ files (or the workflow file itself) are modified, skipping entirely for Go-only or config-only changes.
- **codeql.yml**: Extracted the `c-cpp` CodeQL analysis from the matrix into its own job, gated behind a lightweight `check-c-changes` job on `ubuntu-latest`. On PRs, the expensive macOS c-cpp analysis only runs if C/C++ files changed. On push-to-master, schedule, and manual dispatch it always runs to maintain full security coverage.

## Motivation
The C/C++ codebase is just two files (`gss_darwin.c`, `gss_darwin.h`), but the CodeQL c-cpp analysis and C static analysis workflows were running on every PR regardless of what changed — consuming expensive macOS runner time for no benefit on Go-only PRs.

## Test plan
- [ ] Verify this PR's CI run: `Analyze (c-cpp)` and `C Static Analysis` jobs should be skipped since no C files are in this diff
- [ ] Verify `Analyze (actions)` and `Analyze (go)` still run normally
- [ ] Confirm scheduled/manual runs still trigger c-cpp analysis (no `paths` gate on those events)

https://claude.ai/code/session_01FmykGycEvsVmqFhWvL9jkm