### PR TITLE
fix: address issues #28-35 and #38

### DIFF
--- a/auth_gokrb5.go
+++ b/auth_gokrb5.go
@@ -29,16 +29,12 @@ func getPassword(passwordFile string) (string, error) {
 		if !term.IsTerminal(stdin) {
 			return "", errors.New("no password file specified and stdin is not a terminal")
 		}
-		stdout := int(os.Stdout.Fd())
-		if !term.IsTerminal(stdout) {
-			return "", errors.New("no password file specified and stdout is not a terminal")
-		}
-		fmt.Print("Password: ")
+		fmt.Fprint(os.Stderr, "Password: ")
 		password, err := term.ReadPassword(stdin)
 		if err != nil {
 			return "", fmt.Errorf("failed to read password: %w", err)
 		}
-		fmt.Println()
+		fmt.Fprintln(os.Stderr)
 		return string(password), nil
 	}
 

--- a/circuit_breaker.go
+++ b/circuit_breaker.go
@@ -65,7 +65,7 @@ func (p *CircuitBreakerTokenProvider) GetToken(proxyHost string) (string, error)
 	})
 	if err != nil {
 		if errors.Is(err, gobreaker.ErrOpenState) {
-			return "", fmt.Errorf("circuit breaker open: token acquisition disabled after %d consecutive failures (cooldown %v)", cbConsecutiveFailures, cbTimeout)
+			return "", fmt.Errorf("circuit breaker open: token acquisition disabled after %d consecutive failures", cbConsecutiveFailures)
 		}
 		if errors.Is(err, gobreaker.ErrTooManyRequests) {
 			return "", fmt.Errorf("circuit breaker half-open: probe in progress, rejecting concurrent request")

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/montag451/spnego-proxy
 
 go 1.24.0
 
-toolchain go1.24.7
-
 require (
 	github.com/jcmturner/gokrb5/v8 v8.4.2
 	github.com/sony/gobreaker/v2 v2.4.0

--- a/gss_darwin.c
+++ b/gss_darwin.c
@@ -9,30 +9,35 @@
 #include <stdlib.h>
 #include <string.h>
 
-static void format_gss_error(OM_uint32 major, OM_uint32 minor, char *buf,
-                             size_t buflen) {
+static void append_status_messages(OM_uint32 status_value, int status_type,
+                                   char *buf, size_t buflen, size_t *offset) {
   OM_uint32 msg_ctx = 0;
   OM_uint32 min_stat;
   gss_buffer_desc msg_buf;
-  int first = 1;
-  size_t offset = 0;
 
   do {
-    gss_display_status(&min_stat, major, GSS_C_GSS_CODE, GSS_C_NO_OID, &msg_ctx,
-                       &msg_buf);
-    if (!first && offset < buflen - 2) {
-      buf[offset++] = ';';
-      buf[offset++] = ' ';
+    gss_display_status(&min_stat, status_value, status_type, GSS_C_NO_OID,
+                       &msg_ctx, &msg_buf);
+    if (*offset > 0 && *offset < buflen - 2) {
+      buf[(*offset)++] = ';';
+      buf[(*offset)++] = ' ';
     }
-    size_t to_copy = msg_buf.length < (buflen - offset - 1)
+    size_t to_copy = msg_buf.length < (buflen - *offset - 1)
                          ? msg_buf.length
-                         : (buflen - offset - 1);
-    memcpy(buf + offset, msg_buf.value, to_copy);
-    offset += to_copy;
+                         : (buflen - *offset - 1);
+    memcpy(buf + *offset, msg_buf.value, to_copy);
+    *offset += to_copy;
     gss_release_buffer(&min_stat, &msg_buf);
-    first = 0;
-  } while (msg_ctx != 0 && offset < buflen - 1);
+  } while (msg_ctx != 0 && *offset < buflen - 1);
+}
 
+static void format_gss_error(OM_uint32 major, OM_uint32 minor, char *buf,
+                             size_t buflen) {
+  size_t offset = 0;
+  append_status_messages(major, GSS_C_GSS_CODE, buf, buflen, &offset);
+  if (minor != 0) {
+    append_status_messages(minor, GSS_C_MECH_CODE, buf, buflen, &offset);
+  }
   buf[offset] = '\0';
 }
 
@@ -77,6 +82,10 @@ gss_token_result acquire_spnego_token(const char *spn) {
       NULL   // time_rec
   );
 
+  // GSS_S_CONTINUE_NEEDED is not checked here intentionally. For SPNEGO over
+  // HTTP proxy auth, only the initiator token (first call) is needed. The HTTP
+  // 407 challenge-response loop is handled at the protocol level; each proxy
+  // CONNECT triggers a fresh gss_init_sec_context call.
   if (GSS_ERROR(major)) {
     result.error_code = 1;
     format_gss_error(major, minor, result.error_msg, sizeof(result.error_msg));

--- a/main.go
+++ b/main.go
@@ -41,12 +41,6 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 	if debug {
 		reqReader = bufio.NewReader(io.TeeReader(conn, os.Stdout))
 	}
-	token, err := provider.GetToken(proxy)
-	if err != nil {
-		logger.Printf("failed to get SPNEGO token: %v", err)
-		return
-	}
-	authHeader := "Negotiate " + token
 	_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
 	req, err := http.ReadRequest(reqReader)
 	_ = conn.SetReadDeadline(time.Time{}) // clear after read
@@ -56,7 +50,12 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 		}
 		return
 	}
-	req.Header.Set("Proxy-Authorization", authHeader)
+	token, err := provider.GetToken(proxy)
+	if err != nil {
+		logger.Printf("failed to get SPNEGO token: %v", err)
+		return
+	}
+	req.Header.Set("Proxy-Authorization", "Negotiate "+token)
 	if debug {
 		if err := req.WriteProxy(io.MultiWriter(proxyConn, os.Stdout)); err != nil {
 			logger.Printf("failed to write request to proxy: %v", err)
@@ -71,7 +70,11 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 	var wg sync.WaitGroup
 	forward := func(from, to net.Conn) {
 		defer wg.Done()
-		defer func() { _ = to.(*net.TCPConn).CloseWrite() }()
+		defer func() {
+			if cw, ok := to.(interface{ CloseWrite() error }); ok {
+				_ = cw.CloseWrite()
+			}
+		}()
 		if debug {
 			fromAddr, toAddr := from.RemoteAddr(), to.RemoteAddr()
 			logger.Printf("forward start %v -> %v", fromAddr, toAddr)
@@ -136,7 +139,8 @@ func main() {
 	for {
 		conn, err := l.Accept()
 		if err != nil {
-			logger.Fatal(err)
+			logger.Printf("accept error: %v", err)
+			continue
 		}
 		go handleClient(conn, *proxy, provider, *debug, *dialTimeout, *readTimeout)
 	}


### PR DESCRIPTION
## Summary

Eight bug fixes and improvements across the proxy core, authentication, and circuit breaker:

- **#28/#34** — Accept loop: replace `logger.Fatal` with `log.Printf` + `continue` so transient errors (EMFILE, etc.) don't kill the process or skip deferred cleanup
- **#29** — GSS-API: format the minor (mechanism) status code in error messages, surfacing actionable Kerberos diagnostics
- **#30** — Remove `toolchain go1.24.7` from `go.mod` — a local environment artifact causing spurious diffs
- **#31** — Reorder `handleClient` to read the HTTP request *before* acquiring a SPNEGO token, avoiding wasted KDC round-trips on bad/aborted connections
- **#32** — Remove misleading cooldown duration from circuit breaker open-state error (the state-change log already records timing)
- **#33** — Replace unchecked `*net.TCPConn` type assertion in `forward()` with an interface check to prevent panics with non-TCP connections
- **#35** — Remove overly strict stdout terminal check in `getPassword`; only stdin needs to be a terminal. Prompt now writes to stderr
- **#38** — Document why `GSS_S_CONTINUE_NEEDED` is intentionally not handled in `gss_darwin.c`

Closes #28, closes #29, closes #30, closes #31, closes #32, closes #33, closes #34, closes #35, closes #38

## Test plan

- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -v -count=1 -race ./...` — all 8 tests pass
- [x] `go build ./...` — compiles cleanly
- [ ] CI workflows pass (build, lint, CodeQL, govulncheck)

https://claude.ai/code/session_01FmykGycEvsVmqFhWvL9jkm