### PR TITLE
Security hardening and code quality improvements from codebase review

### DIFF
--- a/auth_gokrb5.go
+++ b/auth_gokrb5.go
@@ -1,13 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
-	"strings"
 	"sync"
 
 	"github.com/jcmturner/gokrb5/v8/client"
@@ -23,31 +22,49 @@ type Gokrb5TokenProvider struct {
 	mu           sync.Mutex
 }
 
-func getPassword(passwordFile string) (string, error) {
+// zeroBytes overwrites a byte slice with zeros to minimize how long
+// sensitive material (passwords) remains in memory.
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+func getPassword(passwordFile string) ([]byte, error) {
 	if passwordFile == "" {
 		stdin := int(os.Stdin.Fd())
 		if !term.IsTerminal(stdin) {
-			return "", errors.New("no password file specified and stdin is not a terminal")
+			return nil, errors.New("no password file specified and stdin is not a terminal")
 		}
 		fmt.Fprint(os.Stderr, "Password: ")
 		password, err := term.ReadPassword(stdin)
 		if err != nil {
-			return "", fmt.Errorf("failed to read password: %w", err)
+			return nil, fmt.Errorf("failed to read password: %w", err)
 		}
 		fmt.Fprintln(os.Stderr)
-		return string(password), nil
+		return password, nil
 	}
 
 	f, err := os.Open(passwordFile) //nolint:gosec // path comes from a CLI flag, not user-controlled input
 	if err != nil {
-		return "", fmt.Errorf("failed to open password file: %w", err)
+		return nil, fmt.Errorf("failed to open password file: %w", err)
 	}
 	defer func() { _ = f.Close() }()
-	password, err := io.ReadAll(f)
+
+	info, err := f.Stat()
 	if err != nil {
-		return "", fmt.Errorf("failed to read password file: %w", err)
+		return nil, fmt.Errorf("failed to stat password file: %w", err)
 	}
-	return strings.TrimRight(string(password), "\r\n"), nil
+	if mode := info.Mode().Perm(); mode&0o077 != 0 {
+		return nil, fmt.Errorf("password file %s has insecure permissions %04o; must not be accessible by group or others (e.g. 0600)", passwordFile, mode)
+	}
+
+	const maxPasswordFileSize = 4096
+	password, err := io.ReadAll(io.LimitReader(f, maxPasswordFileSize))
+	if err != nil {
+		return nil, fmt.Errorf("failed to read password file: %w", err)
+	}
+	return bytes.TrimRight(password, "\r\n"), nil
 }
 
 // NewGokrb5TokenProvider creates a token provider using gokrb5 with password-based auth.
@@ -58,11 +75,7 @@ func NewGokrb5TokenProvider(user, realm, cfgFile, passwordFile, proxy, explicitS
 
 	spnVal := explicitSPN
 	if spnVal == "" {
-		host, _, err := net.SplitHostPort(proxy)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse proxy address: %w", err)
-		}
-		spnVal = "HTTP/" + host
+		spnVal = "HTTP/" + extractHost(proxy)
 		logger.Println("inferred service principal name:", spnVal)
 		logger.Println("if it's not correct use the -spn flag")
 	}
@@ -76,6 +89,7 @@ func NewGokrb5TokenProvider(user, realm, cfgFile, passwordFile, proxy, explicitS
 	if err != nil {
 		return nil, fmt.Errorf("failed to get password: %w", err)
 	}
+	defer zeroBytes(passwd)
 
 	opts := []func(*client.Settings){
 		client.DisablePAFXFAST(true),
@@ -83,14 +97,14 @@ func NewGokrb5TokenProvider(user, realm, cfgFile, passwordFile, proxy, explicitS
 	if debug {
 		opts = append(opts, client.Logger(logger))
 	}
-	cli := client.NewWithPassword(user, realm, passwd, cfg, opts...)
+	cli := client.NewWithPassword(user, realm, string(passwd), cfg, opts...)
 
 	return &Gokrb5TokenProvider{
 		spnegoClient: spnego.SPNEGOClient(cli, spnVal),
 	}, nil
 }
 
-func (p *Gokrb5TokenProvider) GetToken(_ string) (string, error) {
+func (p *Gokrb5TokenProvider) GetToken() (string, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	if err := p.spnegoClient.AcquireCred(); err != nil {

--- a/auth_gss_darwin.go
+++ b/auth_gss_darwin.go
@@ -13,7 +13,7 @@ import "C"
 import (
 	"encoding/base64"
 	"fmt"
-	"net"
+	"sync"
 	"unsafe"
 )
 
@@ -22,6 +22,7 @@ import (
 // credential cache, including the macOS Keychain-based API: cache type.
 type GSSTokenProvider struct {
 	spn string // e.g., "HTTP@proxy.host.com"
+	mu  sync.Mutex
 }
 
 // NewGSSTokenProvider creates a token provider that uses the macOS GSS-API framework.
@@ -29,17 +30,16 @@ type GSSTokenProvider struct {
 func NewGSSTokenProvider(proxyHost, explicitSPN string) (*GSSTokenProvider, error) {
 	spn := explicitSPN
 	if spn == "" {
-		host := proxyHost
-		if h, _, err := net.SplitHostPort(proxyHost); err == nil {
-			host = h
-		}
-		spn = "HTTP@" + host
+		spn = "HTTP@" + extractHost(proxyHost)
 	}
 	logger.Printf("using macOS GSS-API with SPN: %s", spn)
 	return &GSSTokenProvider{spn: spn}, nil
 }
 
-func (g *GSSTokenProvider) GetToken(_ string) (string, error) {
+func (g *GSSTokenProvider) GetToken() (string, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
 	cspn := C.CString(g.spn)
 	defer C.free(unsafe.Pointer(cspn))
 

--- a/auth_gss_darwin_test.go
+++ b/auth_gss_darwin_test.go
@@ -51,7 +51,7 @@ func TestGSSTokenAcquisitionWithoutTickets(t *testing.T) {
 	}
 	defer func() { _ = provider.Close() }()
 
-	_, err = provider.GetToken("proxy.example.com:8080")
+	_, err = provider.GetToken()
 	if err == nil {
 		t.Log("GetToken succeeded — Kerberos tickets must be available in this environment")
 	} else {

--- a/circuit_breaker.go
+++ b/circuit_breaker.go
@@ -59,9 +59,9 @@ func newCircuitBreakerTokenProvider(inner TokenProvider, settings gobreaker.Sett
 
 // GetToken acquires a token from the wrapped provider, subject to circuit
 // breaker policy. Returns a descriptive error when the circuit is open.
-func (p *CircuitBreakerTokenProvider) GetToken(proxyHost string) (string, error) {
+func (p *CircuitBreakerTokenProvider) GetToken() (string, error) {
 	token, err := p.cb.Execute(func() (string, error) {
-		return p.inner.GetToken(proxyHost)
+		return p.inner.GetToken()
 	})
 	if err != nil {
 		if errors.Is(err, gobreaker.ErrOpenState) {

--- a/circuit_breaker_test.go
+++ b/circuit_breaker_test.go
@@ -19,7 +19,7 @@ type stubTokenProvider struct {
 	closed atomic.Bool
 }
 
-func (s *stubTokenProvider) GetToken(_ string) (string, error) {
+func (s *stubTokenProvider) GetToken() (string, error) {
 	s.calls.Add(1)
 	if s.err != nil {
 		return "", s.err
@@ -37,7 +37,7 @@ func (s *stubTokenProvider) Close() error {
 func tripBreaker(t *testing.T, cb *CircuitBreakerTokenProvider) {
 	t.Helper()
 	for i := 0; i < int(cbConsecutiveFailures); i++ {
-		_, err := cb.GetToken("proxy:8080")
+		_, err := cb.GetToken()
 		if err == nil {
 			t.Fatalf("expected error on call %d", i+1)
 		}
@@ -48,7 +48,7 @@ func TestCircuitBreakerPassesThrough(t *testing.T) {
 	inner := &stubTokenProvider{token: "tok123"}
 	cb := NewCircuitBreakerTokenProvider(inner)
 
-	token, err := cb.GetToken("proxy:8080")
+	token, err := cb.GetToken()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestCircuitBreakerOpensAfterConsecutiveFailures(t *testing.T) {
 
 	// Next call should be rejected without calling inner
 	callsBefore := inner.calls.Load()
-	_, err := cb.GetToken("proxy:8080")
+	_, err := cb.GetToken()
 	if err == nil {
 		t.Fatal("expected circuit breaker error")
 	}
@@ -90,12 +90,12 @@ func TestCircuitBreakerDoesNotTripOnIntermittentFailures(t *testing.T) {
 	// Fail twice (below threshold), then succeed
 	inner.err = errors.New("transient")
 	for i := 0; i < int(cbConsecutiveFailures)-1; i++ {
-		_, _ = cb.GetToken("proxy:8080")
+		_, _ = cb.GetToken()
 	}
 
 	// Recover — consecutive counter resets
 	inner.err = nil
-	token, err := cb.GetToken("proxy:8080")
+	token, err := cb.GetToken()
 	if err != nil {
 		t.Fatalf("unexpected error after recovery: %v", err)
 	}
@@ -105,7 +105,7 @@ func TestCircuitBreakerDoesNotTripOnIntermittentFailures(t *testing.T) {
 
 	// Fail again — should still go through (counter was reset)
 	inner.err = errors.New("transient again")
-	_, err = cb.GetToken("proxy:8080")
+	_, err = cb.GetToken()
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -135,7 +135,7 @@ func TestCircuitBreakerOpenRejectsWithoutCallingInner(t *testing.T) {
 
 	// Circuit is now open — verify purely through observable behavior
 	callsBefore := inner.calls.Load()
-	_, err := cb.GetToken("proxy:8080")
+	_, err := cb.GetToken()
 	if err == nil {
 		t.Fatal("expected error while circuit is open")
 	}
@@ -178,7 +178,7 @@ func TestCircuitBreakerHalfOpenRejectsConcurrentRequests(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		go func(idx int) {
 			defer wg.Done()
-			tokens[idx], errs[idx] = cb.GetToken("proxy:8080")
+			tokens[idx], errs[idx] = cb.GetToken()
 		}(i)
 	}
 	wg.Wait()
@@ -209,7 +209,7 @@ type slowTokenProvider struct {
 	token string
 }
 
-func (s *slowTokenProvider) GetToken(_ string) (string, error) {
+func (s *slowTokenProvider) GetToken() (string, error) {
 	time.Sleep(s.delay)
 	return s.token, nil
 }

--- a/main.go
+++ b/main.go
@@ -17,10 +17,19 @@ import (
 
 var logger = log.New(os.Stderr, "", log.LstdFlags)
 
+// extractHost returns the host portion of addr, stripping any port suffix.
+// If addr has no port, it is returned unchanged.
+func extractHost(addr string) string {
+	if h, _, err := net.SplitHostPort(addr); err == nil {
+		return h
+	}
+	return addr
+}
+
 // TokenProvider acquires SPNEGO tokens for proxy authentication.
 type TokenProvider interface {
-	// GetToken returns a base64-encoded SPNEGO token for the given proxy host.
-	GetToken(proxyHost string) (string, error)
+	// GetToken returns a base64-encoded SPNEGO token.
+	GetToken() (string, error)
 	// Close cleans up any resources.
 	Close() error
 }
@@ -38,9 +47,6 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 	}
 	defer func() { _ = proxyConn.Close() }()
 	reqReader := bufio.NewReader(conn)
-	if debug {
-		reqReader = bufio.NewReader(io.TeeReader(conn, os.Stdout))
-	}
 	_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
 	req, err := http.ReadRequest(reqReader)
 	_ = conn.SetReadDeadline(time.Time{}) // clear after read
@@ -50,22 +56,18 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 		}
 		return
 	}
-	token, err := provider.GetToken(proxy)
+	token, err := provider.GetToken()
 	if err != nil {
 		logger.Printf("failed to get SPNEGO token: %v", err)
 		return
 	}
-	req.Header.Set("Proxy-Authorization", "Negotiate "+token)
 	if debug {
-		if err := req.WriteProxy(io.MultiWriter(proxyConn, os.Stdout)); err != nil {
-			logger.Printf("failed to write request to proxy: %v", err)
-			return
-		}
-	} else {
-		if err := req.WriteProxy(proxyConn); err != nil {
-			logger.Printf("failed to write request to proxy: %v", err)
-			return
-		}
+		logger.Printf("proxy request: %s %s %s (headers: %d)", req.Method, req.RequestURI, req.Proto, len(req.Header))
+	}
+	req.Header.Set("Proxy-Authorization", "Negotiate "+token)
+	if err := req.WriteProxy(proxyConn); err != nil {
+		logger.Printf("failed to write request to proxy: %v", err)
+		return
 	}
 	var wg sync.WaitGroup
 	forward := func(from, to net.Conn) {

--- a/main_test.go
+++ b/main_test.go
@@ -41,7 +41,7 @@ func TestHandleClientReadTimeout(t *testing.T) {
 			if err != nil {
 				return
 			}
-			defer func() { _ = conn.Close() }()
+			_ = conn.Close()
 		}
 	}()
 


### PR DESCRIPTION
- Fix debug mode leaking SPNEGO tokens to stdout via MultiWriter; replace
  with structured log summary of request method/URI/headers
- Validate password file permissions (reject if group/other-accessible)
- Cap password file read at 4096 bytes via io.LimitReader
- Zero password byte slices after use to reduce memory exposure window
- Add mutex to GSSTokenProvider.GetToken for thread-safety parity with
  Gokrb5TokenProvider
- Fix defer-in-loop bug in TestHandleClientReadTimeout (conn.Close deferred
  inside for loop never executes per-iteration)
- Remove unused proxyHost parameter from TokenProvider.GetToken interface
- Extract shared extractHost helper to deduplicate SPN host parsing

https://claude.ai/code/session_01W4uPu2fd3xLrMYdWDjqjbC