### PR TITLE
Fix go.mod module path to match repository URL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/montag451/spnego-proxy
+module github.com/andrewesweet/spnego-proxy
 
 go 1.24.0
 


### PR DESCRIPTION
## Summary
- Update `go.mod` module path from `github.com/montag451/spnego-proxy` to `github.com/andrewesweet/spnego-proxy` so that `go install github.com/andrewesweet/spnego-proxy@latest` works as documented in the README

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] CI passes on all platforms (macOS amd64, macOS arm64, Linux)

Fixes #54

https://claude.ai/code/session_015Pow7Di4KxxS6FSrf1MyZo