### PR TITLE
Add connection limiting to accept loop

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.7
 require (
 	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/sony/gobreaker/v2 v2.4.0
+	golang.org/x/net v0.50.0
 	golang.org/x/term v0.40.0
 )
 
@@ -18,6 +19,5 @@ require (
 	github.com/jcmturner/goidentity/v6 v6.0.1 // indirect
 	github.com/jcmturner/rpc/v2 v2.0.3 // indirect
 	golang.org/x/crypto v0.48.0 // indirect
-	golang.org/x/net v0.50.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 )

--- a/main.go
+++ b/main.go
@@ -16,6 +16,8 @@ import (
 	"sync"
 	"syscall"
 	"time"
+
+	"golang.org/x/net/netutil"
 )
 
 var logger = log.New(os.Stderr, "", log.LstdFlags)
@@ -104,6 +106,7 @@ func main() {
 	dialTimeout := flag.Duration("dial-timeout", 30*time.Second, "timeout for connecting to upstream proxy")
 	readTimeout := flag.Duration("read-timeout", 30*time.Second, "timeout for reading client HTTP request")
 	drainTimeout := flag.Duration("drain-timeout", 30*time.Second, "timeout for draining in-flight connections on shutdown")
+	maxConns := flag.Int("max-conns", 512, "maximum number of concurrent connections (0 for unlimited)")
 
 	// Flags for gokrb5 password-based auth (optional on macOS, required on other platforms)
 	cfgFile := flag.String("config", "", "kerberos config file")
@@ -138,7 +141,12 @@ func main() {
 	if err != nil {
 		logger.Fatal(err)
 	}
-	logger.Printf("listening on %s, proxying to %s", *addr, *proxy)
+	if *maxConns > 0 {
+		l = netutil.LimitListener(l, *maxConns)
+		logger.Printf("listening on %s, proxying to %s (max connections: %d)", *addr, *proxy, *maxConns)
+	} else {
+		logger.Printf("listening on %s, proxying to %s", *addr, *proxy)
+	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()

--- a/main_test.go
+++ b/main_test.go
@@ -4,6 +4,8 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"golang.org/x/net/netutil"
 )
 
 func TestHandleClientDialTimeout(t *testing.T) {
@@ -61,5 +63,84 @@ func TestHandleClientReadTimeout(t *testing.T) {
 		// handleClient returned promptly — read deadline fired as expected.
 	case <-time.After(5 * time.Second):
 		t.Fatal("handleClient did not return within 5s; read timeout not effective")
+	}
+}
+
+func TestLimitListenerBlocksAtCapacity(t *testing.T) {
+	const limit = 2
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+	ln = netutil.LimitListener(ln, limit)
+
+	// acceptCh delivers server-side accepted connections for coordination.
+	acceptCh := make(chan net.Conn, limit+1)
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			acceptCh <- c
+		}
+	}()
+
+	// Fill all slots.
+	clients := make([]net.Conn, limit)
+	servers := make([]net.Conn, limit)
+	for i := 0; i < limit; i++ {
+		c, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatalf("dial %d: %v", i, err)
+		}
+		clients[i] = c
+		select {
+		case servers[i] = <-acceptCh:
+		case <-time.After(time.Second):
+			t.Fatalf("timed out waiting for server to accept connection %d", i)
+		}
+	}
+
+	// The next dial may succeed at the TCP level (kernel SYN queue), but
+	// LimitListener.Accept will block on its semaphore.
+	extra, dialErr := net.DialTimeout("tcp", ln.Addr().String(), time.Second)
+	if dialErr == nil {
+		defer func() { _ = extra.Close() }()
+	}
+
+	// Verify Accept has not delivered a third connection yet.
+	select {
+	case c := <-acceptCh:
+		_ = c.Close()
+		t.Fatal("LimitListener accepted beyond its capacity")
+	case <-time.After(100 * time.Millisecond):
+		// Expected: Accept is blocked.
+	}
+
+	// Release one slot by closing a server-side connection (this releases
+	// the LimitListener semaphore).
+	_ = servers[0].Close()
+	_ = clients[0].Close()
+
+	// If the extra dial succeeded, its connection should now be accepted.
+	if extra != nil {
+		select {
+		case c := <-acceptCh:
+			_ = c.Close()
+			// Success: the blocked Accept proceeded after a slot was freed.
+		case <-time.After(time.Second):
+			t.Error("expected blocked connection to be accepted after releasing a slot")
+		}
+	}
+
+	// Clean up remaining connections.
+	for _, c := range clients[1:] {
+		_ = c.Close()
+	}
+	for _, c := range servers[1:] {
+		_ = c.Close()
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a `-max-conns` flag (default 512) that caps the number of concurrent connections using `netutil.LimitListener` from `golang.org/x/net`
- When the limit is reached, `Accept()` blocks until an existing connection closes, providing natural backpressure without dropping connections
- Pass `-max-conns=0` to disable the limit (previous unbounded behavior)

## Test plan
- [x] Added `TestLimitListenerBlocksAtCapacity` verifying that connections beyond the limit block and are accepted once a slot frees up
- [x] All existing tests pass (`go test ./... -count=1`)
- [x] `go vet ./...` clean

Fixes #51

https://claude.ai/code/session_01KVgEaXAgPQXKrLHpBSzMdF