### PR TITLE
Fix Gokrb5TokenProvider.Close() resource leak

### DIFF
--- a/auth_gokrb5.go
+++ b/auth_gokrb5.go
@@ -24,6 +24,7 @@ import (
 // password cannot be reliably zeroed. Use a keytab instead of a password
 // in environments where this is a concern.
 type Gokrb5TokenProvider struct {
+	krbClient    *client.Client
 	spnegoClient *spnego.SPNEGO
 	mu           sync.Mutex
 }
@@ -97,6 +98,7 @@ func NewGokrb5TokenProvider(user, realm, cfgFile, passwordFile, proxy, explicitS
 	cli := client.NewWithPassword(user, realm, string(passwd), cfg, opts...)
 
 	return &Gokrb5TokenProvider{
+		krbClient:    cli,
 		spnegoClient: spnego.SPNEGOClient(cli, spnVal),
 	}, nil
 }
@@ -119,5 +121,11 @@ func (p *Gokrb5TokenProvider) GetToken() (string, error) {
 }
 
 func (p *Gokrb5TokenProvider) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.krbClient != nil {
+		p.krbClient.Destroy()
+		p.krbClient = nil
+	}
 	return nil
 }

--- a/auth_gokrb5_test.go
+++ b/auth_gokrb5_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/jcmturner/gokrb5/v8/client"
+	"github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/spnego"
+)
+
+// minimalKrb5Conf is a minimal krb5.conf sufficient to construct a client
+// without hitting the network.
+const minimalKrb5Conf = `[libdefaults]
+  default_realm = TEST.REALM
+[realms]
+  TEST.REALM = {
+    kdc = 127.0.0.1
+  }
+`
+
+// newTestGokrb5TokenProvider creates a Gokrb5TokenProvider backed by a real
+// (but unconfigured) gokrb5 client, suitable for testing lifecycle methods.
+func newTestGokrb5TokenProvider(t *testing.T) *Gokrb5TokenProvider {
+	t.Helper()
+	cfg, err := config.NewFromString(minimalKrb5Conf)
+	if err != nil {
+		t.Fatalf("failed to parse krb5 config: %v", err)
+	}
+	cli := client.NewWithPassword("user", "TEST.REALM", "pass", cfg)
+	return &Gokrb5TokenProvider{
+		krbClient:    cli,
+		spnegoClient: spnego.SPNEGOClient(cli, "HTTP/proxy.test"),
+	}
+}
+
+func TestGokrb5TokenProviderCloseDestroysClient(t *testing.T) {
+	p := newTestGokrb5TokenProvider(t)
+	if p.krbClient == nil {
+		t.Fatal("expected non-nil krbClient before Close")
+	}
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close() returned error: %v", err)
+	}
+	if p.krbClient != nil {
+		t.Error("expected krbClient to be nil after Close")
+	}
+}
+
+func TestGokrb5TokenProviderCloseIsIdempotent(t *testing.T) {
+	p := newTestGokrb5TokenProvider(t)
+
+	// First close should succeed.
+	if err := p.Close(); err != nil {
+		t.Fatalf("first Close() returned error: %v", err)
+	}
+
+	// Second close must not panic or return an error.
+	if err := p.Close(); err != nil {
+		t.Fatalf("second Close() returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Store a direct `*client.Client` reference on `Gokrb5TokenProvider` alongside the existing `*spnego.SPNEGO` wrapper
- `Close()` now calls `client.Destroy()` to clean up goroutines, session state, and cached tickets
- Nil-guard ensures `Close()` is idempotent (safe to call multiple times)

## Test plan
- [x] `TestGokrb5TokenProviderCloseDestroysClient` — verifies `krbClient` is set to nil after `Close()`
- [x] `TestGokrb5TokenProviderCloseIsIdempotent` — verifies double-close does not panic or error
- [x] All existing tests pass (`go test ./...`)

Fixes #58

https://claude.ai/code/session_01A9B57KpbRHFj72BJ8dKyGN