### PR TITLE
Fix C/C++ CodeQL analysis skipped on push and schedule events

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -64,8 +64,9 @@ jobs:
     name: Analyze (c-cpp)
     needs: check-c-changes
     if: >-
-      github.event_name != 'pull_request' ||
-      needs.check-c-changes.outputs.changed == 'true'
+      !cancelled() &&
+      (github.event_name != 'pull_request' ||
+       needs.check-c-changes.outputs.changed == 'true')
     runs-on: macos-latest
     permissions:
       security-events: write


### PR DESCRIPTION
## Summary

- Fixes the `analyze-c-cpp` job in `codeql.yml` being silently skipped on push, schedule, and manual dispatch events
- Adds `!cancelled()` guard so the job's `if` condition is evaluated even when the `check-c-changes` dependency is skipped

## Problem

The `analyze-c-cpp` job declares `needs: check-c-changes`, but `check-c-changes` only runs on `pull_request` events. On all other events (push to main, weekly cron, manual dispatch), `check-c-changes` is skipped, and GitHub Actions short-circuits the dependent job — never evaluating its `if` condition. This means C/C++ CodeQL security analysis of `gss_darwin.c` only ran on PRs with C file changes, not on the intended weekly schedule or on pushes to main.

## Fix

Added `!cancelled()` to the `analyze-c-cpp` job's `if` expression, which is the standard GitHub Actions pattern for ensuring a dependent job's condition is evaluated even when upstream jobs are skipped:

```yaml
if: >-
  !cancelled() &&
  (github.event_name != 'pull_request' ||
   needs.check-c-changes.outputs.changed == 'true')
```

Behavior after fix:
- **push/schedule/dispatch**: `check-c-changes` is skipped → `!cancelled()` is true, `event_name != 'pull_request'` is true → analysis runs
- **PR with C changes**: `check-c-changes` outputs `changed=true` → analysis runs
- **PR without C changes**: `check-c-changes` outputs `changed=false` → analysis skipped (efficient)
- **Cancelled workflow**: `!cancelled()` is false → analysis skipped

## Test plan

- [ ] Verify actionlint passes (validated locally — no errors)
- [ ] Verify the workflow runs C/C++ analysis on push to main
- [ ] Verify the workflow still gates C/C++ analysis on C file changes for PRs

Fixes #57

https://claude.ai/code/session_01Lj8frjeH1hAjzh1XubUGk2