### PR TITLE
Normalize -spn flag value to match active auth backend format

### DIFF
--- a/auth_gokrb5.go
+++ b/auth_gokrb5.go
@@ -76,6 +76,8 @@ func NewGokrb5TokenProvider(user, realm, cfgFile, passwordFile, proxy, explicitS
 		spnVal = "HTTP/" + extractHost(proxy)
 		logger.Println("inferred service principal name:", spnVal)
 		logger.Println("if it's not correct use the -spn flag")
+	} else {
+		spnVal = normalizeSPN(spnVal, '/', '@')
 	}
 
 	cfg, err := config.Load(cfgFile)

--- a/auth_gss_darwin.go
+++ b/auth_gss_darwin.go
@@ -31,6 +31,8 @@ func NewGSSTokenProvider(proxyHost, explicitSPN string) (*GSSTokenProvider, erro
 	spn := explicitSPN
 	if spn == "" {
 		spn = "HTTP@" + extractHost(proxyHost)
+	} else {
+		spn = normalizeSPN(spn, '@', '/')
 	}
 	logger.Printf("using macOS GSS-API with SPN: %s", spn)
 	return &GSSTokenProvider{spn: spn}, nil

--- a/auth_gss_darwin_test.go
+++ b/auth_gss_darwin_test.go
@@ -42,6 +42,20 @@ func TestGSSTokenProviderNoPort(t *testing.T) {
 	}
 }
 
+func TestGSSTokenProviderNormalizesKrb5SPN(t *testing.T) {
+	// A user passing the Kerberos principal format should have it automatically
+	// converted to the GSS-API hostbased service name format (HTTP@host).
+	provider, err := NewGSSTokenProvider("proxy.example.com:8080", "HTTP/custom.example.com")
+	if err != nil {
+		t.Fatalf("Failed to create GSSTokenProvider: %v", err)
+	}
+	defer func() { _ = provider.Close() }()
+
+	if provider.spn != "HTTP@custom.example.com" {
+		t.Errorf("Expected SPN HTTP@custom.example.com, got %s", provider.spn)
+	}
+}
+
 func TestGSSTokenAcquisitionWithoutTickets(t *testing.T) {
 	// This test verifies the GSS-API call path works even when no tickets
 	// are available. It should return an error (no credentials) rather than crash.

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -29,6 +30,21 @@ func extractHost(addr string) string {
 		return h
 	}
 	return addr
+}
+
+// normalizeSPN converts an explicit SPN between GSS-API hostbased format
+// (service@host) and Kerberos principal format (service/host) so the user
+// need not know which backend is active. targetSep is the separator the
+// active backend expects ('@' for GSS-API, '/' for gokrb5); alternateSep
+// is the other backend's separator.
+func normalizeSPN(spn string, targetSep, alternateSep byte) string {
+	if strings.IndexByte(spn, targetSep) >= 0 {
+		return spn // already contains the target separator
+	}
+	if i := strings.IndexByte(spn, alternateSep); i >= 0 {
+		return spn[:i] + string(targetSep) + spn[i+1:]
+	}
+	return spn // no recognized separator; return as-is
 }
 
 // TokenProvider acquires SPNEGO tokens for proxy authentication.
@@ -100,7 +116,7 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 func main() {
 	addr := flag.String("addr", "127.0.0.1:8080", "bind address")
 	proxy := flag.String("proxy", "", "proxy address")
-	spn := flag.String("spn", "", "service principal name (default: HTTP@<proxy-host>)")
+	spn := flag.String("spn", "", "service principal name; accepts service@host or service/host (default: derived from -proxy)")
 	debug := flag.Bool("debug", false, "turn on debugging")
 
 	dialTimeout := flag.Duration("dial-timeout", 30*time.Second, "timeout for connecting to upstream proxy")

--- a/spn_test.go
+++ b/spn_test.go
@@ -1,0 +1,40 @@
+package main
+
+import "testing"
+
+func TestNormalizeSPN(t *testing.T) {
+	tests := []struct {
+		name         string
+		spn          string
+		targetSep    byte
+		alternateSep byte
+		want         string
+	}{
+		// GSS-API target separator is '@'
+		{"gss: already correct format", "HTTP@host.example.com", '@', '/', "HTTP@host.example.com"},
+		{"gss: convert from krb5 format", "HTTP/host.example.com", '@', '/', "HTTP@host.example.com"},
+		{"gss: no recognized separator", "host.example.com", '@', '/', "host.example.com"},
+
+		// gokrb5 target separator is '/'
+		{"krb5: already correct format", "HTTP/host.example.com", '/', '@', "HTTP/host.example.com"},
+		{"krb5: convert from gss format", "HTTP@host.example.com", '/', '@', "HTTP/host.example.com"},
+		{"krb5: no recognized separator", "host.example.com", '/', '@', "host.example.com"},
+
+		// Both separators present — target found, return as-is
+		{"both seps: target found first", "HTTP/host@REALM", '/', '@', "HTTP/host@REALM"},
+		{"both seps: target found first gss", "HTTP@host/path", '@', '/', "HTTP@host/path"},
+
+		// Non-HTTP service types
+		{"gss: custom service type", "CIFS/fileserver.example.com", '@', '/', "CIFS@fileserver.example.com"},
+		{"krb5: custom service type", "CIFS@fileserver.example.com", '/', '@', "CIFS/fileserver.example.com"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeSPN(tt.spn, tt.targetSep, tt.alternateSep)
+			if got != tt.want {
+				t.Errorf("normalizeSPN(%q, %q, %q) = %q, want %q",
+					tt.spn, string(tt.targetSep), string(tt.alternateSep), got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Each auth backend expects a different SPN separator: GSS-API uses
service@host while gokrb5 uses service/host. Previously, an explicit
-spn value was passed verbatim, causing silent auth failures when the
user supplied the wrong format for their active backend.

Each provider now normalizes the explicit SPN to its expected format,
so users can pass either HTTP@host or HTTP/host regardless of which
backend is active.

Fixes #59

https://claude.ai/code/session_015eBZyitQjmBk5FeQAxW2RJ