### PR TITLE
Add Linux amd64 binary to release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -70,3 +70,59 @@ jobs:
         with:
           name: spnego-proxy-darwin-${{ matrix.arch }}.sbom.spdx.json
           path: spnego-proxy-darwin-${{ matrix.arch }}.sbom.spdx.json
+
+  build-linux:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version-file: .go-version
+
+      - name: Build (linux/amd64)
+        env:
+          GOARCH: amd64
+          GOOS: linux
+          CGO_ENABLED: "0"
+        run: go build -v -trimpath -o spnego-proxy-linux-amd64 .
+
+      - name: Verify binary
+        run: file spnego-proxy-linux-amd64
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@96278af6caaf10aea03fd8d33a09a777ca52d62f # v3.2.0
+        with:
+          subject-path: spnego-proxy-linux-amd64
+
+      - name: Generate SBOM
+        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad # v0.22.2
+        with:
+          path: .
+          format: spdx-json
+          output-file: spnego-proxy-linux-amd64.sbom.spdx.json
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Attest SBOM
+        uses: actions/attest-sbom@4651f806c01d8637787e274ac3bdf724ef169f34 # v3.0.0
+        with:
+          subject-path: spnego-proxy-linux-amd64
+          sbom-path: spnego-proxy-linux-amd64.sbom.spdx.json
+
+      - name: Upload binary
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: spnego-proxy-linux-amd64
+          path: spnego-proxy-linux-amd64
+
+      - name: Upload SBOM
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: spnego-proxy-linux-amd64.sbom.spdx.json
+          path: spnego-proxy-linux-amd64.sbom.spdx.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,10 @@ jobs:
           files: |
             artifacts/spnego-proxy-darwin-amd64
             artifacts/spnego-proxy-darwin-arm64
+            artifacts/spnego-proxy-linux-amd64
             artifacts/spnego-proxy-darwin-amd64.sbom.spdx.json
             artifacts/spnego-proxy-darwin-arm64.sbom.spdx.json
+            artifacts/spnego-proxy-linux-amd64.sbom.spdx.json
             artifacts/checksums-sha256.txt
 
       - name: Publish release (makes it immutable)


### PR DESCRIPTION
## Summary
- Adds a `build-linux` job to `build-release.yml` that builds a statically-linked `linux/amd64` binary (`CGO_ENABLED=0`) with build-provenance attestation and SBOM generation, mirroring the existing macOS job structure
- Updates `release.yml` files list to include the Linux binary and its SBOM in GitHub Releases
- The checksums file (`shasum -a 256 spnego-proxy-*`) naturally picks up the new artifact

Closes #55

## Test plan
- [ ] Verify the `Build and Test` CI workflow passes on this branch (linux build + tests already exercised there)
- [ ] Verify YAML is syntactically valid and all action SHA pins match existing usage
- [ ] On a future tagged release, confirm the Linux binary and SBOM appear in the draft release assets

https://claude.ai/code/session_01JFLJeY1o1WsiRCmzkaiP9i