### PR TITLE
Fix SPN default format in flags table (#63)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ All flags:
 | ---- | ----------- | -------- |
 | `-addr` | Listen address (default: `127.0.0.1:8080`) | Yes |
 | `-proxy` | Upstream proxy address | Yes |
-| `-spn` | Service principal name (default: `HTTP/<proxy-host>`) | No |
+| `-spn` | Service principal name (default: `HTTP@<proxy-host>` on macOS, `HTTP/<proxy-host>` on Linux) | No |
 | `-debug` | Enable debug logging | No |
 | `-config` | Kerberos config file path | Password mode only |
 | `-user` | Kerberos username (triggers password-based auth on macOS) | Password mode only |


### PR DESCRIPTION
## Summary
- Updated the `-spn` flag description in the README flags table to document both platform-specific defaults: `HTTP@<proxy-host>` on macOS (GSS-API) and `HTTP/<proxy-host>` on Linux (gokrb5)
- The table previously only showed the Linux/gokrb5 format, which was inconsistent with the macOS GSS-API mode documented earlier in the README

Closes #63

## Test plan
- [ ] Verify the flags table renders correctly in GitHub markdown
- [ ] Confirm the documented defaults match the source code (`auth_gss_darwin.go:33` and `auth_gokrb5.go:77`)

https://claude.ai/code/session_01SnVKqPp38vXAEmz2iM5PKx