### PR TITLE
Fix README flags table: mark -addr as not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ All flags:
 
 | Flag | Description | Required |
 | ---- | ----------- | -------- |
-| `-addr` | Listen address (default: `127.0.0.1:8080`) | Yes |
+| `-addr` | Listen address (default: `127.0.0.1:8080`) | No |
 | `-proxy` | Upstream proxy address | Yes |
 | `-spn` | Service principal name (default: `HTTP/<proxy-host>`) | No |
 | `-debug` | Enable debug logging | No |


### PR DESCRIPTION
## Summary

- Fixes the `-addr` flag being incorrectly marked as "Required: Yes" in the README flags table
- The flag has a default value of `127.0.0.1:8080` (`main.go:117`), making it optional
- The validation check at `main.go:134` (`if *addr == "" || *proxy == ""`) can never trigger for `-addr` since it always has a default value

Fixes #62

## Test plan

- [ ] Verify the README flags table now shows `-addr` as "No" in the Required column
- [ ] Confirm no other documentation inconsistencies were introduced

https://claude.ai/code/session_01QpfwtY8Gu8Lhuzafj3ghdr