### PR TITLE
Add unit test coverage for gokrb5 authentication path

### DIFF
--- a/auth_gokrb5_test.go
+++ b/auth_gokrb5_test.go
@@ -37,14 +37,18 @@ func newTestGokrb5TokenProvider(t *testing.T) *Gokrb5TokenProvider {
 }
 
 // writePasswordFile creates a temporary file with the given content and
-// permissions, returning its path. The file is automatically removed when the
-// test finishes.
+// permissions, returning its path. It uses os.Chmod after writing to set
+// the exact permissions regardless of the process umask. The file is
+// automatically removed when the test finishes.
 func writePasswordFile(t *testing.T, content string, perm os.FileMode) string {
 	t.Helper()
 	dir := t.TempDir()
 	path := filepath.Join(dir, "password")
-	if err := os.WriteFile(path, []byte(content), perm); err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("failed to write password file: %v", err)
+	}
+	if err := os.Chmod(path, perm); err != nil {
+		t.Fatalf("failed to chmod password file: %v", err)
 	}
 	return path
 }


### PR DESCRIPTION
## Summary

- Adds comprehensive unit tests for all previously untested functions in `auth_gokrb5.go`, addressing the lack of test coverage identified in #61
- Covers `getPassword()` (file permissions, size limit, `\r\n` trimming, error paths), `NewGokrb5TokenProvider()` (validation, SPN inference, config/password errors), and `GetToken()` (invalid credential error path)
- Adds 15 new test functions with table-driven subtests where appropriate, preserving all existing tests

## Test plan

- [x] All tests pass locally with `CGO_ENABLED=0 go test -v -count=1 ./...`
- [x] `go vet ./...` passes
- [ ] CI build-and-test workflow passes on both Linux and macOS
- [ ] CI golangci-lint workflow passes

Closes #61

https://claude.ai/code/session_01Mku7GpoZNJWPYmiLEDA9du