### PR TITLE
Add unit tests to release build workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,6 +23,12 @@ jobs:
         with:
           go-version-file: .go-version
 
+      - name: Run unit tests
+        if: matrix.arch == 'arm64'
+        env:
+          CGO_ENABLED: "1"
+        run: go test -v -count=1 ./...
+
       - name: Build (darwin/${{ matrix.arch }})
         env:
           GOARCH: ${{ matrix.arch }}
@@ -84,6 +90,11 @@ jobs:
         uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:
           go-version-file: .go-version
+
+      - name: Run unit tests
+        env:
+          CGO_ENABLED: "0"
+        run: go test -v -count=1 ./...
 
       - name: Build (linux/amd64)
         env:


### PR DESCRIPTION
## Summary

- Adds `go test -v -count=1 ./...` steps to `build-release.yml` for both the macOS arm64 and Linux jobs, running before binary builds
- Provides defense-in-depth against releasing untested code, since tags can be pushed to any commit regardless of CI status
- No changes needed to `release.yml` — it already gates on `needs: build`, so test failures will block the release

## Test plan

- [ ] Verify the macOS arm64 job runs unit tests before building the binary
- [ ] Verify the macOS amd64 job skips unit tests (cross-compiled, can't run on runner)
- [ ] Verify the Linux job runs unit tests before building the binary
- [ ] Verify a test failure in `build-release.yml` prevents the release job from running

Closes #66

https://claude.ai/code/session_01VHbwUJLd9TGfaNMkZMmnST