### PR TITLE
Fix client-to-proxy forwarding to use buffered reader

### DIFF
--- a/main.go
+++ b/main.go
@@ -108,7 +108,7 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 		return
 	}
 	var wg sync.WaitGroup
-	forward := func(from, to net.Conn) {
+	forward := func(from io.Reader, to net.Conn, fromAddr, toAddr net.Addr) {
 		defer wg.Done()
 		defer func() {
 			if cw, ok := to.(interface{ CloseWrite() error }); ok {
@@ -116,17 +116,16 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 			}
 		}()
 		if debug {
-			fromAddr, toAddr := from.RemoteAddr(), to.RemoteAddr()
 			logger.Printf("forward start %v -> %v", fromAddr, toAddr)
 			defer logger.Printf("forward done %v -> %v", fromAddr, toAddr)
 		}
 		if _, err := io.Copy(to, from); err != nil {
-			logger.Printf("forward error %v -> %v: %v", from.RemoteAddr(), to.RemoteAddr(), err)
+			logger.Printf("forward error %v -> %v: %v", fromAddr, toAddr, err)
 		}
 	}
 	wg.Add(2)
-	go forward(conn, proxyConn)
-	go forward(proxyConn, conn)
+	go forward(reqReader, proxyConn, conn.RemoteAddr(), proxyConn.RemoteAddr())
+	go forward(proxyConn, conn, proxyConn.RemoteAddr(), conn.RemoteAddr())
 	wg.Wait()
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -526,3 +526,112 @@ func TestHandleClientTokenErrorCONNECTReturns502(t *testing.T) {
 		t.Fatal("handleClient did not return within 5s")
 	}
 }
+
+// TestHandleClientForwardsBufferedData verifies that data buffered by
+// bufio.NewReader beyond the initial HTTP request is forwarded to the
+// upstream proxy (issue #67). This simulates an HTTP pipelining scenario
+// where the client sends additional bytes in the same segment as the
+// request headers.
+func TestHandleClientForwardsBufferedData(t *testing.T) {
+	// extraPayload is additional data sent immediately after the HTTP
+	// request, in the same write — it will be buffered by bufio.NewReader
+	// but never consumed by http.ReadRequest.
+	const extraPayload = "EXTRA-PIPELINED-DATA"
+
+	// Start a fake upstream proxy that echoes back the CONNECT 200,
+	// then reads and records everything the proxy sends after the
+	// initial request.
+	gotExtra := make(chan string, 1)
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = upstream.Close() }()
+	go func() {
+		conn, err := upstream.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+
+		// Read the initial CONNECT request forwarded by handleClient.
+		reader := bufio.NewReader(conn)
+		req, err := http.ReadRequest(reader)
+		if err != nil {
+			gotExtra <- "READ_ERR: " + err.Error()
+			return
+		}
+		_ = req.Body.Close()
+
+		// Send 200 to complete the CONNECT handshake.
+		_, _ = conn.Write([]byte("HTTP/1.1 200 Connection Established\r\n\r\n"))
+
+		// Now read whatever comes next — this should include extraPayload
+		// that was buffered by the proxy's bufio.NewReader.
+		buf := make([]byte, 4096)
+		n, _ := reader.Read(buf)
+		gotExtra <- string(buf[:n])
+	}()
+
+	// Set up the local proxy listener.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	provider := &stubTokenProvider{token: "tok"}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second)
+	}()
+
+	// Connect to the local proxy and send a CONNECT request followed
+	// immediately by extra data in the same write, so it lands in the
+	// same bufio buffer as the request headers.
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	connectReq := "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n" + extraPayload
+	if _, err := io.WriteString(client, connectReq); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Read the 200 response relayed back from upstream.
+	resp, err := http.ReadResponse(bufio.NewReader(client), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	// Close client side to unblock forwarding goroutines.
+	_ = client.Close()
+
+	// Verify upstream received the extra payload.
+	select {
+	case got := <-gotExtra:
+		if got != extraPayload {
+			t.Errorf("upstream received %q, want %q", got, extraPayload)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for upstream to receive extra payload")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleClient did not return within 5s")
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `handleClient` to forward from `reqReader` (buffered reader) instead of raw `conn` for the client-to-proxy direction, ensuring pre-buffered bytes (e.g. from HTTP pipelining) are not lost
- Update the `forward` closure signature to accept `io.Reader` for the source and pass `net.Addr` separately for debug logging
- Add `TestHandleClientForwardsBufferedData` to verify extra data sent in the same segment as the CONNECT request is properly forwarded upstream

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] New `TestHandleClientForwardsBufferedData` test passes — sends a CONNECT request with appended payload in the same write and verifies upstream receives it
- [ ] CI checks pass

Fixes #67

https://claude.ai/code/session_01JUbEx2hb8MA1uz2Ctn2Tok