### PR TITLE
Send HTTP error responses for all handleClient failure paths

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,6 +79,7 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 	proxyConn, err := net.DialTimeout("tcp", proxy, dialTimeout)
 	if err != nil {
 		logger.Printf("failed to connect to proxy: %v", err)
+		writeHTTPError(conn, http.StatusBadGateway, "failed to connect to upstream proxy\n")
 		return
 	}
 	defer func() { _ = proxyConn.Close() }()
@@ -89,6 +90,7 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 	if err != nil {
 		if !errors.Is(err, io.EOF) {
 			logger.Printf("failed to read request: %v", err)
+			writeHTTPError(conn, http.StatusBadRequest, "failed to read client request\n")
 		}
 		return
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -29,6 +29,21 @@ func TestHandleClientDialTimeout(t *testing.T) {
 		handleClient(server, unreachable, provider, false, 50*time.Millisecond, time.Second)
 	}()
 
+	// The proxy should respond with 502 when it can't reach the upstream.
+	resp, err := http.ReadResponse(bufio.NewReader(client), nil)
+	if err != nil {
+		t.Fatalf("expected HTTP error response, got read error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("expected status 502, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "failed to connect to upstream proxy") {
+		t.Errorf("expected body to mention upstream proxy connection failure, got: %q", body)
+	}
+
 	select {
 	case <-done:
 		// handleClient returned promptly — dial timed out as expected.
@@ -64,6 +79,21 @@ func TestHandleClientReadTimeout(t *testing.T) {
 		defer close(done)
 		handleClient(server, upstream.Addr().String(), provider, false, 5*time.Second, 50*time.Millisecond)
 	}()
+
+	// The proxy should respond with 400 when it can't read the client request.
+	resp, err := http.ReadResponse(bufio.NewReader(client), nil)
+	if err != nil {
+		t.Fatalf("expected HTTP error response, got read error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Errorf("expected status 400, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "failed to read client request") {
+		t.Errorf("expected body to mention client request read failure, got: %q", body)
+	}
 
 	select {
 	case <-done:


### PR DESCRIPTION
## Summary
- Send `502 Bad Gateway` to clients when the upstream proxy connection fails, instead of silently closing the TCP connection
- Send `400 Bad Request` to clients when reading the HTTP request fails (non-EOF), instead of silently closing
- Updated existing tests (`TestHandleClientDialTimeout`, `TestHandleClientReadTimeout`) to verify the new HTTP error responses

Closes #68

## Test plan
- [x] `TestHandleClientDialTimeout` — verifies 502 response on upstream connection failure
- [x] `TestHandleClientReadTimeout` — verifies 400 response on malformed/timed-out request read
- [x] `TestHandleClientTokenErrorReturns502` — existing test, still passes (token path already had 502)
- [x] `TestHandleClientTokenErrorCONNECTReturns502` — existing test, still passes (CONNECT path)
- [x] All 30 tests pass, `go vet` and `gofmt` clean

https://claude.ai/code/session_01GkXKVkkh1HQTsJ1D7f3K1r