### PR TITLE
Add top-level permissions block to build-and-test.yml

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   build-macos:
     runs-on: macos-latest


### PR DESCRIPTION
Restrict GITHUB_TOKEN scope to contents: read, following the principle
of least privilege already established by the other workflow files in
this repository. Fixes #64.

https://claude.ai/code/session_01DyeeY8CP9g6WgzC2FYGHiw