### PR TITLE
Move stubTokenProvider to testutil_test.go

### DIFF
--- a/circuit_breaker_test.go
+++ b/circuit_breaker_test.go
@@ -4,33 +4,11 @@ import (
 	"errors"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	gobreaker "github.com/sony/gobreaker/v2"
 )
-
-// stubTokenProvider is a controllable TokenProvider for testing.
-type stubTokenProvider struct {
-	calls  atomic.Int64
-	err    error  // when non-nil, GetToken returns this error
-	token  string // returned on success
-	closed atomic.Bool
-}
-
-func (s *stubTokenProvider) GetToken() (string, error) {
-	s.calls.Add(1)
-	if s.err != nil {
-		return "", s.err
-	}
-	return s.token, nil
-}
-
-func (s *stubTokenProvider) Close() error {
-	s.closed.Store(true)
-	return nil
-}
 
 // tripBreaker drives cbConsecutiveFailures failures through the provider to
 // open the circuit. The inner stub must already have a non-nil err.

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -1,0 +1,26 @@
+package main
+
+import "sync/atomic"
+
+// stubTokenProvider is a controllable TokenProvider for testing.
+// It lives in a dedicated file so the cross-file dependency between
+// test files that use it is explicit and discoverable.
+type stubTokenProvider struct {
+	calls  atomic.Int64
+	err    error  // when non-nil, GetToken returns this error
+	token  string // returned on success
+	closed atomic.Bool
+}
+
+func (s *stubTokenProvider) GetToken() (string, error) {
+	s.calls.Add(1)
+	if s.err != nil {
+		return "", s.err
+	}
+	return s.token, nil
+}
+
+func (s *stubTokenProvider) Close() error {
+	s.closed.Store(true)
+	return nil
+}


### PR DESCRIPTION
## Summary
- Extracts the shared `stubTokenProvider` test helper from `circuit_breaker_test.go` into a dedicated `testutil_test.go` file
- Makes the cross-file dependency between `main_test.go` and `circuit_breaker_test.go` explicit and discoverable
- Follows Go convention for test helpers used across multiple test files in the same package

Closes #69

## Test plan
- [x] `go vet ./...` passes
- [x] `go test ./...` passes — all existing tests continue to work unchanged

https://claude.ai/code/session_01BNJnRQY955TBG1qLqVFko7