### PR TITLE
Set GOOS explicitly in build-and-test macOS build step

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Build (darwin/${{ matrix.arch }})
         env:
           GOARCH: ${{ matrix.arch }}
+          GOOS: darwin
           CGO_ENABLED: "1"
           CC: ${{ matrix.arch == 'amd64' && 'clang -arch x86_64' || 'clang -arch arm64' }}
         run: go build -v -o spnego-proxy-darwin-${{ matrix.arch }} .


### PR DESCRIPTION
## Summary
- Add `GOOS: darwin` to the macOS build step env in `build-and-test.yml` for consistency with `build-release.yml`
- No functional change — the runner is macOS so `GOOS` defaults to `darwin`, but this makes the cross-compilation configuration explicit

Closes #76

## Test plan
- [ ] Verify `build-macos` CI jobs pass on both `amd64` and `arm64`
- [ ] Verify `build-linux` CI job is unaffected

https://claude.ai/code/session_01X7ZW46Nt3zPgNwzeuJZQ6D