### PR TITLE
Add -trimpath to CI build commands

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -32,7 +32,7 @@ jobs:
           GOARCH: ${{ matrix.arch }}
           CGO_ENABLED: "1"
           CC: ${{ matrix.arch == 'amd64' && 'clang -arch x86_64' || 'clang -arch arm64' }}
-        run: go build -v -o spnego-proxy-darwin-${{ matrix.arch }} .
+        run: go build -v -trimpath -o spnego-proxy-darwin-${{ matrix.arch }} .
 
       - name: Verify binary architecture
         run: |
@@ -75,7 +75,7 @@ jobs:
       - name: Build (linux/amd64 - gokrb5 fallback)
         env:
           CGO_ENABLED: "0"
-        run: go build -v -o spnego-proxy-linux-amd64 .
+        run: go build -v -trimpath -o spnego-proxy-linux-amd64 .
 
       - name: Verify binary
         run: file spnego-proxy-linux-amd64


### PR DESCRIPTION
## Summary

- Add `-trimpath` flag to both macOS and Linux build commands in `build-and-test.yml`, matching the existing usage in `build-release.yml`

Closes #72

## Test plan

- [ ] Verify `Build and Test` workflow passes on all matrix targets (macOS amd64/arm64, Linux amd64)
- [ ] Confirm `-trimpath` is present in build step logs

https://claude.ai/code/session_01AZCPeFXc4KbsEyaDgrGkgK