### PR TITLE
Replace release checksum glob with explicit file list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,17 @@ jobs:
           path: artifacts/
           merge-multiple: true
 
-      - name: Generate checksums
+      - name: Generate checksums for all release artifacts
         working-directory: artifacts
-        run: shasum -a 256 spnego-proxy-* > checksums-sha256.txt
+        run: |
+          shasum -a 256 \
+            spnego-proxy-darwin-amd64 \
+            spnego-proxy-darwin-arm64 \
+            spnego-proxy-linux-amd64 \
+            spnego-proxy-darwin-amd64.sbom.spdx.json \
+            spnego-proxy-darwin-arm64.sbom.spdx.json \
+            spnego-proxy-linux-amd64.sbom.spdx.json \
+            > checksums-sha256.txt
 
       - name: Detect pre-release from SemVer tag
         id: semver


### PR DESCRIPTION
## Summary

- Replaces the ambiguous `spnego-proxy-*` glob in the release checksum step with an explicit list of all 6 release artifacts (3 binaries + 3 SBOMs)
- Renames the step to "Generate checksums for all release artifacts" to clarify intent
- The checksummed file list now visibly mirrors the release asset list, preventing unintentional inclusion of future files matching the glob

Fixes #71

## Test plan

- [ ] Verify `lint-workflows` CI check passes (actionlint validates the updated YAML)
- [ ] Confirm no other CI checks regress
- [ ] On next tagged release, verify `checksums-sha256.txt` contains exactly 6 entries (3 binaries + 3 SBOMs)

https://claude.ai/code/session_012TZFrZjhtgf4fToQk95tug