### PR TITLE
Add fork author copyright to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2021, montag451.
+Copyright (c) 2026, andrewesweet.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
## Summary

- Adds `Copyright (c) 2026, andrewesweet.` to the LICENSE file to reflect the fork's substantial contributions (native macOS GSS-API support, circuit breaker, CI/CD pipeline, release workflow, SBOM/attestation, comprehensive testing)
- Preserves the original upstream copyright `Copyright (c) 2021, montag451.` as required by MIT license
- Uses year 2026 per maintainer direction in [issue comment](https://github.com/andrewesweet/spnego-proxy/issues/73#issuecomment-3963005468)

Resolves #73

## Test plan

- [ ] Verify LICENSE file contains both copyright lines
- [ ] Verify original copyright is preserved unchanged
- [ ] Verify CI checks pass (no code changes, documentation-only)

https://claude.ai/code/session_019NfCypakx2i9Nj7XoDsyZ8