### PR TITLE
Refactor half-open circuit breaker test to avoid direct field mutation

### DIFF
--- a/circuit_breaker_test.go
+++ b/circuit_breaker_test.go
@@ -126,10 +126,14 @@ func TestCircuitBreakerOpenRejectsWithoutCallingInner(t *testing.T) {
 }
 
 func TestCircuitBreakerHalfOpenRejectsConcurrentRequests(t *testing.T) {
-	// Use a very short timeout so the circuit transitions to half-open quickly,
-	// and a slow inner provider so the probe is still in-flight when concurrent
-	// requests arrive.
-	inner := &stubTokenProvider{err: errors.New("fail")}
+	// Use a single stub that starts in "fail" mode to trip the breaker, then
+	// switches to "slow success" mode for the half-open probe. This avoids
+	// directly mutating cb.inner and keeps the test decoupled from field names.
+	inner := &stubTokenProvider{
+		err:   errors.New("fail"),
+		token: "recovered",
+		delay: 200 * time.Millisecond,
+	}
 	cb := newCircuitBreakerTokenProvider(inner, gobreaker.Settings{
 		Name:        "test-concurrent",
 		MaxRequests: 1,
@@ -144,9 +148,10 @@ func TestCircuitBreakerHalfOpenRejectsConcurrentRequests(t *testing.T) {
 	// Wait for the circuit to transition to half-open
 	time.Sleep(100 * time.Millisecond)
 
-	// Now make inner slow so the probe blocks while concurrent callers fire
-	slowInner := &slowTokenProvider{delay: 200 * time.Millisecond, token: "recovered"}
-	cb.inner = slowInner
+	// Switch the stub to succeed slowly so the probe blocks while concurrent
+	// callers arrive. No goroutines are running at this point, so the
+	// unsynchronised write is safe.
+	inner.err = nil
 
 	const concurrency = 5
 	errs := make([]error, concurrency)
@@ -178,20 +183,4 @@ func TestCircuitBreakerHalfOpenRejectsConcurrentRequests(t *testing.T) {
 	if tooMany != concurrency-1 {
 		t.Errorf("expected %d ErrTooManyRequests rejections, got %d", concurrency-1, tooMany)
 	}
-}
-
-// slowTokenProvider introduces a delay before returning, used to keep the
-// half-open probe in-flight while concurrent requests arrive.
-type slowTokenProvider struct {
-	delay time.Duration
-	token string
-}
-
-func (s *slowTokenProvider) GetToken() (string, error) {
-	time.Sleep(s.delay)
-	return s.token, nil
-}
-
-func (s *slowTokenProvider) Close() error {
-	return nil
 }

--- a/testutil_test.go
+++ b/testutil_test.go
@@ -1,19 +1,26 @@
 package main
 
-import "sync/atomic"
+import (
+	"sync/atomic"
+	"time"
+)
 
 // stubTokenProvider is a controllable TokenProvider for testing.
 // It lives in a dedicated file so the cross-file dependency between
 // test files that use it is explicit and discoverable.
 type stubTokenProvider struct {
 	calls  atomic.Int64
-	err    error  // when non-nil, GetToken returns this error
-	token  string // returned on success
+	err    error         // when non-nil, GetToken returns this error
+	token  string        // returned on success
+	delay  time.Duration // artificial latency before returning
 	closed atomic.Bool
 }
 
 func (s *stubTokenProvider) GetToken() (string, error) {
 	s.calls.Add(1)
+	if s.delay > 0 {
+		time.Sleep(s.delay)
+	}
 	if s.err != nil {
 		return "", s.err
 	}


### PR DESCRIPTION
## Summary
- Resolves #77: the half-open circuit breaker test (`TestCircuitBreakerHalfOpenRejectsConcurrentRequests`) previously mutated `cb.inner` directly, coupling the test to the struct's internal field names
- Adds a `delay` field to `stubTokenProvider` so it can serve as both a failing and slow-success provider
- Replaces the `cb.inner = slowInner` assignment with `inner.err = nil`, toggling the same stub from fail to succeed mode
- Removes the now-unused `slowTokenProvider` type

## Test plan
- [x] All circuit breaker tests pass with `-race` enabled
- [x] Full test suite passes (`go test -race ./...`)
- [ ] CI workflows (build, lint, tests) pass on this branch

https://claude.ai/code/session_013gwxKB4dcG2RRgsqa1N2Dy