### PR TITLE
Add SPN() accessor to GSSTokenProvider

### DIFF
--- a/auth_gss_darwin.go
+++ b/auth_gss_darwin.go
@@ -49,6 +49,11 @@ func NewGSSTokenProvider(proxyHost, explicitSPN string) (*GSSTokenProvider, erro
 	return g, nil
 }
 
+// SPN returns the service principal name used for token acquisition.
+func (g *GSSTokenProvider) SPN() string {
+	return g.spn
+}
+
 func (g *GSSTokenProvider) GetToken() (string, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()

--- a/auth_gss_darwin_test.go
+++ b/auth_gss_darwin_test.go
@@ -13,8 +13,8 @@ func TestGSSTokenProviderInit(t *testing.T) {
 	}
 	defer func() { _ = provider.Close() }()
 
-	if provider.spn != "HTTP@proxy.example.com" {
-		t.Errorf("Expected SPN HTTP@proxy.example.com, got %s", provider.spn)
+	if provider.SPN() != "HTTP@proxy.example.com" {
+		t.Errorf("Expected SPN HTTP@proxy.example.com, got %s", provider.SPN())
 	}
 }
 
@@ -25,8 +25,8 @@ func TestGSSTokenProviderExplicitSPN(t *testing.T) {
 	}
 	defer func() { _ = provider.Close() }()
 
-	if provider.spn != "HTTP@custom.example.com" {
-		t.Errorf("Expected SPN HTTP@custom.example.com, got %s", provider.spn)
+	if provider.SPN() != "HTTP@custom.example.com" {
+		t.Errorf("Expected SPN HTTP@custom.example.com, got %s", provider.SPN())
 	}
 }
 
@@ -37,8 +37,8 @@ func TestGSSTokenProviderNoPort(t *testing.T) {
 	}
 	defer func() { _ = provider.Close() }()
 
-	if provider.spn != "HTTP@proxy.example.com" {
-		t.Errorf("Expected SPN HTTP@proxy.example.com, got %s", provider.spn)
+	if provider.SPN() != "HTTP@proxy.example.com" {
+		t.Errorf("Expected SPN HTTP@proxy.example.com, got %s", provider.SPN())
 	}
 }
 
@@ -51,8 +51,8 @@ func TestGSSTokenProviderNormalizesKrb5SPN(t *testing.T) {
 	}
 	defer func() { _ = provider.Close() }()
 
-	if provider.spn != "HTTP@custom.example.com" {
-		t.Errorf("Expected SPN HTTP@custom.example.com, got %s", provider.spn)
+	if provider.SPN() != "HTTP@custom.example.com" {
+		t.Errorf("Expected SPN HTTP@custom.example.com, got %s", provider.SPN())
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds an exported `SPN() string` accessor method to `GSSTokenProvider` so tests (and callers) can inspect the service principal name without accessing the unexported `spn` field
- Updates all 4 test assertions in `auth_gss_darwin_test.go` to use `provider.SPN()` instead of `provider.spn`
- Decouples tests from internal struct representation, improving maintainability

Closes #78

## Test plan
- [x] `go build ./...` passes (Linux, no-CGO)
- [x] `go vet ./...` passes
- [x] `go test -v -count=1 ./...` passes — all 32 tests pass
- [ ] CI: build-and-test (macOS arm64/amd64 + Linux)
- [ ] CI: golangci-lint (Linux no-CGO + macOS CGO)
- [ ] CI: CodeQL analysis
- [ ] CI: govulncheck
- [ ] CI: C static analysis
- [ ] CI: markdown lint
- [ ] CI: workflow lint

https://claude.ai/code/session_01DyEx4r4X5orM3iMh6AtLuy