### PR TITLE
Fix flaky half-open circuit breaker test

### DIFF
--- a/circuit_breaker_test.go
+++ b/circuit_breaker_test.go
@@ -163,8 +163,16 @@ func TestCircuitBreakerHalfOpenRejectsConcurrentRequests(t *testing.T) {
 
 	tripBreaker(t, cb)
 
-	// Wait for the circuit to transition to half-open
-	time.Sleep(100 * time.Millisecond)
+	// Poll until the circuit transitions to half-open instead of using a
+	// fixed sleep, which is fragile on slow or overloaded CI systems.
+	deadline := time.After(2 * time.Second)
+	for cb.cb.State() != gobreaker.StateHalfOpen {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for circuit breaker to transition to half-open")
+		case <-time.After(1 * time.Millisecond):
+		}
+	}
 
 	// Now make inner slow so the probe blocks while concurrent callers fire
 	slowInner := &slowTokenProvider{delay: 200 * time.Millisecond, token: "recovered"}


### PR DESCRIPTION
## Summary
- Replace fixed `time.Sleep(100ms)` in `TestCircuitBreakerHalfOpenRejectsConcurrentRequests` with a polling loop that checks `cb.State()` for the half-open transition
- Eliminates timing-dependent failures on slow or overloaded CI systems
- Verified with 20 consecutive test runs (all passing)

Closes #70

## Test plan
- [x] All existing tests pass (`go test ./...`)
- [x] The previously-flaky test passes reliably (20/20 runs)
- [ ] CI checks pass

https://claude.ai/code/session_01CFK5z9nMkhkS143Vi1oMRk