### PR TITLE
Enable TCP keepalive on forwarded connections

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,15 @@ type TokenProvider interface {
 	Close() error
 }
 
+// enableKeepAlive enables TCP keepalive on conn with the given period.
+// Non-TCP connections (e.g. net.Pipe in tests) are silently skipped.
+func enableKeepAlive(conn net.Conn, period time.Duration) {
+	if tc, ok := conn.(*net.TCPConn); ok {
+		_ = tc.SetKeepAlive(true)
+		_ = tc.SetKeepAlivePeriod(period)
+	}
+}
+
 // writeHTTPError sends a minimal HTTP error response to the client.
 // It is best-effort; write failures are silently ignored because the
 // connection is about to be closed.
@@ -70,7 +79,7 @@ func writeHTTPError(conn net.Conn, statusCode int, reason string) {
 	_ = resp.Write(conn)
 }
 
-func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug bool, dialTimeout, readTimeout time.Duration) {
+func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug bool, dialTimeout, readTimeout, keepAlive time.Duration) {
 	defer func() { _ = conn.Close() }()
 	if debug {
 		defer logger.Printf("stop processing request for client: %v", conn.RemoteAddr())
@@ -109,6 +118,10 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 		writeHTTPError(conn, http.StatusBadGateway, "failed to relay request to upstream proxy\n")
 		return
 	}
+	if keepAlive > 0 {
+		enableKeepAlive(conn, keepAlive)
+		enableKeepAlive(proxyConn, keepAlive)
+	}
 	var wg sync.WaitGroup
 	forward := func(from io.Reader, to net.Conn, fromAddr, toAddr net.Addr) {
 		defer wg.Done()
@@ -140,6 +153,7 @@ func main() {
 	dialTimeout := flag.Duration("dial-timeout", 30*time.Second, "timeout for connecting to upstream proxy")
 	readTimeout := flag.Duration("read-timeout", 30*time.Second, "timeout for reading client HTTP request")
 	drainTimeout := flag.Duration("drain-timeout", 30*time.Second, "timeout for draining in-flight connections on shutdown")
+	keepAlive := flag.Duration("keepalive", 30*time.Second, "TCP keepalive period for idle connection detection (0 to disable)")
 	maxConns := flag.Int("max-conns", 512, "maximum number of concurrent connections (0 for unlimited)")
 
 	// Flags for gokrb5 password-based auth (optional on macOS, required on other platforms)
@@ -201,7 +215,7 @@ func main() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				handleClient(conn, *proxy, provider, *debug, *dialTimeout, *readTimeout)
+				handleClient(conn, *proxy, provider, *debug, *dialTimeout, *readTimeout, *keepAlive)
 			}()
 		}
 	}()

--- a/main_test.go
+++ b/main_test.go
@@ -44,7 +44,7 @@ func TestHandleClientDialTimeout(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleClient(server, unreachable, provider, false, 50*time.Millisecond, time.Second)
+		handleClient(server, unreachable, provider, false, 50*time.Millisecond, time.Second, 0)
 	}()
 
 	// The proxy should respond with 502 when it can't reach the upstream.
@@ -95,7 +95,7 @@ func TestHandleClientReadTimeout(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleClient(server, upstream.Addr().String(), provider, false, 5*time.Second, 50*time.Millisecond)
+		handleClient(server, upstream.Addr().String(), provider, false, 5*time.Second, 50*time.Millisecond, 0)
 	}()
 
 	// The proxy should respond with 400 when it can't read the client request.
@@ -298,7 +298,7 @@ func TestShutdownDrainsInFlightConnections(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second)
+				handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
 			}()
 		}
 	}()
@@ -399,7 +399,7 @@ func TestShutdownDrainTimeout(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second)
+				handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
 			}()
 		}
 	}()
@@ -475,7 +475,7 @@ func TestHandleClientTokenErrorReturns502(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleClient(server, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second)
+		handleClient(server, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
 	}()
 
 	// Send a request through the client side of the pipe.
@@ -543,7 +543,7 @@ func TestHandleClientTokenErrorCONNECTReturns502(t *testing.T) {
 		if err != nil {
 			return
 		}
-		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second)
+		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
 	}()
 
 	client, err := net.Dial("tcp", ln.Addr().String())
@@ -636,7 +636,7 @@ func TestHandleClientForwardsBufferedData(t *testing.T) {
 		if err != nil {
 			return
 		}
-		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second)
+		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
 	}()
 
 	// Connect to the local proxy and send a CONNECT request followed
@@ -726,7 +726,7 @@ func TestCloseWriteCalledOnForwardCompletion(t *testing.T) {
 			return
 		}
 		wrapped.Conn = conn
-		handleClient(wrapped, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second)
+		handleClient(wrapped, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
 	}()
 
 	// Connect to the local proxy and send a request.
@@ -764,5 +764,123 @@ func TestCloseWriteCalledOnForwardCompletion(t *testing.T) {
 	// conn, so CloseWrite must have been called on it at least once.
 	if n := wrapped.closeWriteCalls.Load(); n == 0 {
 		t.Error("expected CloseWrite to be called on the client connection, but it was not")
+	}
+}
+
+func TestEnableKeepAlive(t *testing.T) {
+	// enableKeepAlive should configure keepalive on real TCP connections
+	// without error.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	accepted := make(chan net.Conn, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- c
+	}()
+
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = clientConn.Close() }()
+
+	select {
+	case serverConn := <-accepted:
+		defer func() { _ = serverConn.Close() }()
+		// Should succeed on TCP connections without panic.
+		enableKeepAlive(serverConn, 30*time.Second)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for accept")
+	}
+	enableKeepAlive(clientConn, 30*time.Second)
+
+	// Should be a silent no-op on non-TCP connections (e.g. net.Pipe).
+	a, b := net.Pipe()
+	defer func() { _ = a.Close() }()
+	defer func() { _ = b.Close() }()
+	enableKeepAlive(a, 30*time.Second)
+	enableKeepAlive(b, 30*time.Second)
+}
+
+// TestHandleClientKeepAlive verifies that handleClient works correctly
+// when TCP keepalive is enabled on forwarded connections (issue #74).
+func TestHandleClientKeepAlive(t *testing.T) {
+	// Start a fake upstream proxy that echoes a valid HTTP response.
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = upstream.Close() }()
+	go func() {
+		for {
+			conn, err := upstream.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				buf := make([]byte, 4096)
+				_, _ = c.Read(buf)
+				resp := "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
+				_, _ = c.Write([]byte(resp))
+			}(conn)
+		}
+	}()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = ln.Close() }()
+
+	provider := &stubTokenProvider{token: "tok"}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		// Pass a non-zero keepalive to exercise the keepalive code path.
+		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 30*time.Second)
+	}()
+
+	client, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	if err := req.WriteProxy(client); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(client), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if string(body) != "OK" {
+		t.Errorf("expected body %q, got %q", "OK", body)
+	}
+
+	_ = client.Close()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleClient did not return within 5s")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds a `-keepalive` flag (default 30s, `0` to disable) that enables TCP keepalive on both client and upstream proxy connections before bidirectional forwarding begins
- Detects dead peers (network partition, client crash, firewall state expiry) via OS-level TCP keepalive probes, preventing zombie goroutines and file descriptor exhaustion
- Adds `enableKeepAlive` helper that gracefully handles non-TCP connections (silent no-op for `net.Pipe` in tests)

Closes #74

## Test plan
- [x] `TestEnableKeepAlive` — verifies keepalive works on real TCP connections and is a no-op on non-TCP connections (net.Pipe)
- [x] `TestHandleClientKeepAlive` — integration test exercising the full handleClient path with keepalive enabled
- [x] All existing tests pass with keepalive parameter (set to 0 to preserve existing behavior)
- [x] Race detector enabled (`-race`), all tests pass
- [x] `go vet ./...` passes

https://claude.ai/code/session_01ENXvg4CzzvuZZ8q2g8TYRY