### PR TITLE
Add RFC 9209 Proxy-Status header and structured JSON logging

### DIFF
--- a/auth_gokrb5.go
+++ b/auth_gokrb5.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sync"
 
@@ -75,8 +76,8 @@ func NewGokrb5TokenProvider(user, realm, cfgFile, passwordFile, proxy, explicitS
 	spnVal := explicitSPN
 	if spnVal == "" {
 		spnVal = "HTTP/" + extractHost(proxy)
-		logger.Println("inferred service principal name:", spnVal)
-		logger.Println("if it's not correct use the -spn flag")
+		slog.Info("inferred service principal name", "spn", spnVal)
+		slog.Info("if it's not correct use the -spn flag")
 	} else {
 		spnVal = normalizeSPN(spnVal, '/', '@')
 	}
@@ -95,7 +96,7 @@ func NewGokrb5TokenProvider(user, realm, cfgFile, passwordFile, proxy, explicitS
 		client.DisablePAFXFAST(true),
 	}
 	if debug {
-		opts = append(opts, client.Logger(logger))
+		opts = append(opts, client.Logger(slog.NewLogLogger(slog.Default().Handler(), slog.LevelDebug)))
 	}
 	cli := client.NewWithPassword(user, realm, string(passwd), cfg, opts...)
 

--- a/auth_gss_darwin.go
+++ b/auth_gss_darwin.go
@@ -13,6 +13,7 @@ import "C"
 import (
 	"encoding/base64"
 	"fmt"
+	"log/slog"
 	"os"
 	"sync"
 	"unsafe"
@@ -35,15 +36,15 @@ func NewGSSTokenProvider(proxyHost, explicitSPN string) (*GSSTokenProvider, erro
 	} else {
 		spn = normalizeSPN(spn, '@', '/')
 	}
-	logger.Printf("using macOS GSS-API with SPN: %s", spn)
+	slog.Info("using macOS GSS-API", "spn", spn)
 	g := &GSSTokenProvider{spn: spn}
 
 	// Validate credentials are available at startup. This is a warning,
 	// not a fatal error, because credentials may become available later
 	// (e.g. kinit run after the proxy starts).
 	if _, err := g.GetToken(); err != nil {
-		logger.Printf("WARNING: initial credential check failed: %v", err)
-		logger.Printf("the proxy will retry on each request; run 'kinit' to obtain credentials")
+		slog.Warn("initial credential check failed", "error", err)
+		slog.Warn("the proxy will retry on each request; run 'kinit' to obtain credentials")
 	}
 
 	return g, nil

--- a/circuit_breaker.go
+++ b/circuit_breaker.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"log/slog"
 	"time"
 
 	gobreaker "github.com/sony/gobreaker/v2"
@@ -45,7 +46,7 @@ func NewCircuitBreakerTokenProvider(inner TokenProvider) *CircuitBreakerTokenPro
 			return counts.ConsecutiveFailures >= cbConsecutiveFailures
 		},
 		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
-			logger.Printf("circuit breaker %q: %s -> %s", name, from, to)
+			slog.Warn("circuit breaker state change", "name", name, "from", from.String(), "to", to.String())
 		},
 	})
 }

--- a/gokrb5_integration_test.go
+++ b/gokrb5_integration_test.go
@@ -136,7 +136,7 @@ func TestProxyChainWithRealToken(t *testing.T) {
 		if err != nil {
 			return
 		}
-		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
+		handleClient(conn, upstream.Addr().String(), provider, 5*time.Second, 5*time.Second, 0)
 	}()
 
 	// Connect and send a request through the proxy.

--- a/integration_gss_darwin_test.go
+++ b/integration_gss_darwin_test.go
@@ -284,7 +284,7 @@ func TestGSSProxyChainWithEphemeralKDC(t *testing.T) {
 		if err != nil {
 			return
 		}
-		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
+		handleClient(conn, upstream.Addr().String(), provider, 5*time.Second, 5*time.Second, 0)
 	}()
 
 	// Connect and send a request through the proxy.

--- a/main.go
+++ b/main.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"flag"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"os"
@@ -21,7 +21,13 @@ import (
 	"golang.org/x/net/netutil"
 )
 
-var logger = log.New(os.Stderr, "", log.LstdFlags)
+var logLevel = new(slog.LevelVar) // default Info
+
+func init() {
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
+		Level: logLevel,
+	})))
+}
 
 // extractHost returns the host portion of addr, stripping any port suffix.
 // If addr has no port, it is returned unchanged.
@@ -97,20 +103,19 @@ func writeHTTPError(conn net.Conn, statusCode int, proxyStatusError string, reas
 	_ = resp.Write(conn)
 }
 
-func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug bool, dialTimeout, readTimeout, keepAlive time.Duration) {
+func handleClient(conn net.Conn, proxy string, provider TokenProvider, dialTimeout, readTimeout, keepAlive time.Duration) {
 	defer func() { _ = conn.Close() }()
-	if debug {
-		defer logger.Printf("stop processing request for client: %v", conn.RemoteAddr())
-		logger.Printf("new client: %v", conn.RemoteAddr())
-	}
+	clientAddr := conn.RemoteAddr().String()
+	slog.Debug("new client", "client_addr", clientAddr)
+	defer slog.Debug("stop processing request", "client_addr", clientAddr)
 	proxyConn, err := net.DialTimeout("tcp", proxy, dialTimeout)
 	if err != nil {
 		var ne net.Error
 		if errors.As(err, &ne) && ne.Timeout() {
-			logger.Printf("failed to connect to proxy: %v", err)
+			slog.Error("failed to connect to proxy", "error", err, "error_type", proxyErrConnectionTimeout, "client_addr", clientAddr, "upstream_addr", proxy)
 			writeHTTPError(conn, http.StatusGatewayTimeout, proxyErrConnectionTimeout, "failed to connect to upstream proxy\n")
 		} else {
-			logger.Printf("failed to connect to proxy: %v", err)
+			slog.Error("failed to connect to proxy", "error", err, "error_type", proxyErrConnectionRefused, "client_addr", clientAddr, "upstream_addr", proxy)
 			writeHTTPError(conn, http.StatusBadGateway, proxyErrConnectionRefused, "failed to connect to upstream proxy\n")
 		}
 		return
@@ -122,23 +127,21 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 	_ = conn.SetReadDeadline(time.Time{}) // clear after read
 	if err != nil {
 		if !errors.Is(err, io.EOF) {
-			logger.Printf("failed to read request: %v", err)
+			slog.Error("failed to read request", "error", err, "error_type", proxyErrHTTPRequestError, "client_addr", clientAddr)
 			writeHTTPError(conn, http.StatusBadRequest, proxyErrHTTPRequestError, "failed to read client request\n")
 		}
 		return
 	}
 	token, err := provider.GetToken()
 	if err != nil {
-		logger.Printf("failed to get SPNEGO token: %v", err)
+		slog.Error("failed to get SPNEGO token", "error", err, "error_type", proxyErrProxyInternalError, "client_addr", clientAddr, "upstream_addr", proxy, "method", req.Method, "host", req.Host)
 		writeHTTPError(conn, http.StatusBadGateway, proxyErrProxyInternalError, "proxy authentication failed\n")
 		return
 	}
-	if debug {
-		logger.Printf("proxy request: %s %s %s (headers: %d)", req.Method, req.RequestURI, req.Proto, len(req.Header))
-	}
+	slog.Debug("proxy request", "method", req.Method, "uri", req.RequestURI, "proto", req.Proto, "headers", len(req.Header), "client_addr", clientAddr, "upstream_addr", proxy)
 	req.Header.Set("Proxy-Authorization", "Negotiate "+token)
 	if err := req.WriteProxy(proxyConn); err != nil {
-		logger.Printf("failed to write request to proxy: %v", err)
+		slog.Error("failed to write request to proxy", "error", err, "error_type", proxyErrConnectionTerminated, "client_addr", clientAddr, "upstream_addr", proxy, "method", req.Method, "host", req.Host)
 		writeHTTPError(conn, http.StatusBadGateway, proxyErrConnectionTerminated, "failed to relay request to upstream proxy\n")
 		return
 	}
@@ -154,12 +157,10 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, debug boo
 				_ = cw.CloseWrite()
 			}
 		}()
-		if debug {
-			logger.Printf("forward start %v -> %v", fromAddr, toAddr)
-			defer logger.Printf("forward done %v -> %v", fromAddr, toAddr)
-		}
+		slog.Debug("forward start", "from", fromAddr, "to", toAddr)
+		defer slog.Debug("forward done", "from", fromAddr, "to", toAddr)
 		if _, err := io.Copy(to, from); err != nil {
-			logger.Printf("forward error %v -> %v: %v", fromAddr, toAddr, err)
+			slog.Error("forward error", "error", err, "from", fromAddr, "to", toAddr)
 		}
 	}
 	wg.Add(2)
@@ -187,8 +188,12 @@ func main() {
 	passwordFile := flag.String("password-file", "", "password file path")
 	flag.Parse()
 
+	if *debug {
+		logLevel.Set(slog.LevelDebug)
+	}
+
 	if *addr == "" || *proxy == "" {
-		logger.Println("-addr and -proxy are required")
+		slog.Error("-addr and -proxy are required")
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -205,19 +210,21 @@ func main() {
 	}
 	if err != nil {
 		// codeql[go/clear-text-logging]
-		logger.Fatal(err)
+		slog.Error("failed to create token provider", "error", err)
+		os.Exit(1)
 	}
 	provider = NewCircuitBreakerTokenProvider(provider)
 
 	l, err := net.Listen("tcp", *addr)
 	if err != nil {
-		logger.Fatal(err)
+		slog.Error("failed to listen", "error", err, "addr", *addr)
+		os.Exit(1)
 	}
 	if *maxConns > 0 {
 		l = netutil.LimitListener(l, *maxConns)
-		logger.Printf("listening on %s, proxying to %s (max connections: %d)", *addr, *proxy, *maxConns)
+		slog.Info("listening", "addr", *addr, "proxy", *proxy, "max_conns", *maxConns)
 	} else {
-		logger.Printf("listening on %s, proxying to %s", *addr, *proxy)
+		slog.Info("listening", "addr", *addr, "proxy", *proxy)
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
@@ -233,28 +240,28 @@ func main() {
 					return
 				default:
 				}
-				logger.Printf("accept error: %v", err)
+				slog.Error("accept error", "error", err)
 				continue
 			}
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				handleClient(conn, *proxy, provider, *debug, *dialTimeout, *readTimeout, *keepAlive)
+				handleClient(conn, *proxy, provider, *dialTimeout, *readTimeout, *keepAlive)
 			}()
 		}
 	}()
 
 	<-ctx.Done()
-	logger.Println("shutting down, draining connections...")
+	slog.Info("shutting down, draining connections...")
 	_ = l.Close()
 
 	done := make(chan struct{})
 	go func() { wg.Wait(); close(done) }()
 	select {
 	case <-done:
-		logger.Println("all connections drained")
+		slog.Info("all connections drained")
 	case <-time.After(*drainTimeout):
-		logger.Println("drain timeout exceeded, forcing exit")
+		slog.Warn("drain timeout exceeded, forcing exit")
 	}
 	_ = provider.Close()
 }

--- a/main_test.go
+++ b/main_test.go
@@ -44,7 +44,7 @@ func TestHandleClientDialTimeout(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleClient(server, unreachable, provider, false, 50*time.Millisecond, time.Second, 0)
+		handleClient(server, unreachable, provider, 50*time.Millisecond, time.Second, 0)
 	}()
 
 	// The proxy should respond with 504 when the dial times out (RFC 9209 connection_timeout).
@@ -98,7 +98,7 @@ func TestHandleClientReadTimeout(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleClient(server, upstream.Addr().String(), provider, false, 5*time.Second, 50*time.Millisecond, 0)
+		handleClient(server, upstream.Addr().String(), provider, 5*time.Second, 50*time.Millisecond, 0)
 	}()
 
 	// The proxy should respond with 400 when it can't read the client request.
@@ -304,7 +304,7 @@ func TestShutdownDrainsInFlightConnections(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
+				handleClient(conn, upstream.Addr().String(), provider, 5*time.Second, 5*time.Second, 0)
 			}()
 		}
 	}()
@@ -405,7 +405,7 @@ func TestShutdownDrainTimeout(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
+				handleClient(conn, upstream.Addr().String(), provider, 5*time.Second, 5*time.Second, 0)
 			}()
 		}
 	}()
@@ -481,7 +481,7 @@ func TestHandleClientTokenErrorReturns502(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		handleClient(server, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
+		handleClient(server, upstream.Addr().String(), provider, 5*time.Second, 5*time.Second, 0)
 	}()
 
 	// Send a request through the client side of the pipe.
@@ -552,7 +552,7 @@ func TestHandleClientTokenErrorCONNECTReturns502(t *testing.T) {
 		if err != nil {
 			return
 		}
-		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
+		handleClient(conn, upstream.Addr().String(), provider, 5*time.Second, 5*time.Second, 0)
 	}()
 
 	client, err := net.Dial("tcp", ln.Addr().String())
@@ -648,7 +648,7 @@ func TestHandleClientForwardsBufferedData(t *testing.T) {
 		if err != nil {
 			return
 		}
-		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
+		handleClient(conn, upstream.Addr().String(), provider, 5*time.Second, 5*time.Second, 0)
 	}()
 
 	// Connect to the local proxy and send a CONNECT request followed
@@ -738,7 +738,7 @@ func TestCloseWriteCalledOnForwardCompletion(t *testing.T) {
 			return
 		}
 		wrapped.Conn = conn
-		handleClient(wrapped, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 0)
+		handleClient(wrapped, upstream.Addr().String(), provider, 5*time.Second, 5*time.Second, 0)
 	}()
 
 	// Connect to the local proxy and send a request.
@@ -861,7 +861,7 @@ func TestHandleClientKeepAlive(t *testing.T) {
 			return
 		}
 		// Pass a non-zero keepalive to exercise the keepalive code path.
-		handleClient(conn, upstream.Addr().String(), provider, false, 5*time.Second, 5*time.Second, 30*time.Second)
+		handleClient(conn, upstream.Addr().String(), provider, 5*time.Second, 5*time.Second, 30*time.Second)
 	}()
 
 	client, err := net.Dial("tcp", ln.Addr().String())


### PR DESCRIPTION
## Summary
- Add RFC 9209 `Proxy-Status` header to all proxy-generated error responses with structured error tokens (`connection_timeout`, `connection_refused`, `http_request_error`, `proxy_internal_error`, `connection_terminated`)
- Change dial timeout errors from 502 to 504 Gateway Timeout per RFC 9209 recommendation, using `errors.As` for `net.Error` timeout detection
- Replace unstructured `log.Printf` logging with structured JSON logging via `log/slog` across all files (`main.go`, `circuit_breaker.go`, `auth_gokrb5.go`, `auth_gss_darwin.go`)
- Map `-debug` flag to `slog.LevelDebug` vs `slog.LevelInfo` instead of boolean guards
- Bridge gokrb5 `client.Logger` to slog via `slog.NewLogLogger`

## Test plan
- [x] Updated `TestHandleClientDialTimeout` to verify 504 status and `Proxy-Status: spnego-proxy; error=connection_timeout`
- [x] Updated `TestHandleClientReadTimeout` to verify `Proxy-Status: spnego-proxy; error=http_request_error`
- [x] Updated `TestHandleClientTokenErrorReturns502` to verify `Proxy-Status: spnego-proxy; error=proxy_internal_error`
- [x] Updated `TestHandleClientTokenErrorCONNECTReturns502` to verify `Proxy-Status: spnego-proxy; error=proxy_internal_error`
- [x] Updated all test call sites to match new `handleClient` signature (removed `debug` parameter)
- [x] Full test suite passes (`go test -count=1 ./...`)
- [x] `go vet` and `gofmt` clean
- [x] All CI checks pass (lint, build, CodeQL, vulnerability check)

Resolves #112

https://claude.ai/code/session_01Ez1F2aHsLUrJmNnKZP14xp