### PR TITLE
Add structured error response bodies for proxy-generated errors

### DIFF
--- a/circuit_breaker.go
+++ b/circuit_breaker.go
@@ -58,18 +58,37 @@ func newCircuitBreakerTokenProvider(inner TokenProvider, settings gobreaker.Sett
 	return &CircuitBreakerTokenProvider{inner: inner, cb: cb}
 }
 
+// CircuitBreakerError indicates that the circuit breaker rejected a request.
+// The Unwrap method returns the underlying gobreaker sentinel so callers can
+// further distinguish open vs half-open states with errors.Is if needed.
+type CircuitBreakerError struct {
+	msg   string
+	cause error
+}
+
+func (e *CircuitBreakerError) Error() string { return e.msg }
+func (e *CircuitBreakerError) Unwrap() error { return e.cause }
+
 // GetToken acquires a token from the wrapped provider, subject to circuit
-// breaker policy. Returns a descriptive error when the circuit is open.
+// breaker policy. Returns a *CircuitBreakerError when the circuit is open
+// or half-open, allowing callers to distinguish circuit breaker rejections
+// from other token acquisition failures using errors.As.
 func (p *CircuitBreakerTokenProvider) GetToken() (string, error) {
 	token, err := p.cb.Execute(func() (string, error) {
 		return p.inner.GetToken()
 	})
 	if err != nil {
 		if errors.Is(err, gobreaker.ErrOpenState) {
-			return "", fmt.Errorf("circuit breaker open: token acquisition disabled after %d consecutive failures", cbConsecutiveFailures)
+			return "", &CircuitBreakerError{
+				msg:   fmt.Sprintf("circuit breaker open: token acquisition disabled after %d consecutive failures", cbConsecutiveFailures),
+				cause: err,
+			}
 		}
 		if errors.Is(err, gobreaker.ErrTooManyRequests) {
-			return "", fmt.Errorf("circuit breaker half-open: probe in progress, rejecting concurrent request")
+			return "", &CircuitBreakerError{
+				msg:   "circuit breaker half-open: probe in progress, rejecting concurrent request",
+				cause: err,
+			}
 		}
 		return "", err
 	}

--- a/main.go
+++ b/main.go
@@ -191,8 +191,13 @@ func handleClient(conn net.Conn, proxy string, provider TokenProvider, dialTimeo
 	}
 	token, err := provider.GetToken()
 	if err != nil {
-		slog.Error("failed to get SPNEGO token", "error", err, "error_type", errTokenAcquisition.errorType, "client_addr", clientAddr, "upstream_addr", proxy, "method", req.Method, "host", req.Host)
-		writeHTTPError(conn, errTokenAcquisition)
+		pe := errTokenAcquisition
+		var cbErr *CircuitBreakerError
+		if errors.As(err, &cbErr) {
+			pe = errCircuitBreakerOpen
+		}
+		slog.Error("failed to get SPNEGO token", "error", err, "error_type", pe.errorType, "client_addr", clientAddr, "upstream_addr", proxy, "method", req.Method, "host", req.Host)
+		writeHTTPError(conn, pe)
 		return
 	}
 	slog.Debug("proxy request", "method", req.Method, "uri", req.RequestURI, "proto", req.Proto, "headers", len(req.Header), "client_addr", clientAddr, "upstream_addr", proxy)

--- a/main_test.go
+++ b/main_test.go
@@ -531,6 +531,77 @@ func TestHandleClientTokenErrorReturns502(t *testing.T) {
 	}
 }
 
+func TestHandleClientCircuitBreakerErrorReturnsDistinctBody(t *testing.T) {
+	// Verify that a circuit breaker error produces a distinct body from
+	// a regular token acquisition error (issue #113, section 4).
+	upstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = upstream.Close() }()
+	go func() {
+		for {
+			conn, err := upstream.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				buf := make([]byte, 4096)
+				_, _ = c.Read(buf)
+			}(conn)
+		}
+	}()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+
+	// Use a CircuitBreakerError to simulate the circuit breaker being open.
+	provider := &stubTokenProvider{err: &CircuitBreakerError{
+		msg:   "circuit breaker open: token acquisition disabled after 3 consecutive failures",
+		cause: errors.New("gobreaker: open state"),
+	}}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		handleClient(server, upstream.Addr().String(), provider, 5*time.Second, 5*time.Second, 0)
+	}()
+
+	req, _ := http.NewRequest("GET", "http://example.com/", nil)
+	_ = req.WriteProxy(client)
+
+	resp, err := http.ReadResponse(bufio.NewReader(client), req)
+	if err != nil {
+		t.Fatalf("expected HTTP error response, got read error: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("expected status 502, got %d", resp.StatusCode)
+	}
+	if ps := resp.Header.Get("Proxy-Status"); ps != "spnego-proxy; error=proxy_internal_error" {
+		t.Errorf("expected Proxy-Status header %q, got %q", "spnego-proxy; error=proxy_internal_error", ps)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	bodyStr := string(body)
+	if !strings.Contains(bodyStr, "circuit breaker open") {
+		t.Errorf("expected body to mention circuit breaker, got: %q", body)
+	}
+	if !strings.Contains(bodyStr, "temporarily disabled after repeated failures") {
+		t.Errorf("expected body to describe circuit breaker state, got: %q", body)
+	}
+	// The circuit breaker body should NOT contain the regular token error message.
+	if strings.Contains(bodyStr, "failed to acquire a SPNEGO authentication token") {
+		t.Errorf("expected circuit breaker body to differ from regular token error, got: %q", body)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handleClient did not return within 5s")
+	}
+}
+
 func TestHandleClientTokenErrorCONNECTReturns502(t *testing.T) {
 	// Verify CONNECT requests also get a 502 (this is the common case
 	// for HTTPS traffic through a proxy, and what curl uses).


### PR DESCRIPTION
## Summary

Resolves #113. Enriches proxy-generated error response bodies with structured, categorized information so clients and operators can quickly understand what went wrong and what action to take.

- Introduces `proxyError` struct with error type, human-readable description, and suggested remediation action; refactors `writeHTTPError` to render structured plain-text bodies
- Defines 6 pre-defined error constants covering all proxy error paths: `connection_timeout`, `connection_refused`, `proxy_internal_error`, `http_request_error`, `connection_terminated`
- Introduces `CircuitBreakerError` typed error (with `errors.As` detection) to distinguish circuit breaker rejections from regular token failures, per owner feedback on section 4
- Updates Content-Type to `text/plain; charset=utf-8`
- Updates all existing error response tests and adds circuit breaker error body test with HTTP/CONNECT symmetry verification

### Example output (before → after)

**Before:**
```
HTTP/1.1 502 Bad Gateway
Content-Type: text/plain

proxy authentication failed
```

**After:**
```
HTTP/1.1 502 Bad Gateway
Content-Type: text/plain; charset=utf-8
Proxy-Status: spnego-proxy; error=proxy_internal_error

spnego-proxy error: proxy_internal_error

The proxy failed to acquire a SPNEGO authentication token.

Suggested action: Check Kerberos credentials. Run 'klist' to verify a valid
ticket exists, or 'kinit' to obtain a new one.
```

### Follow-up

Raised #119 to evaluate extending typed errors to auth provider `GetToken()` failures for even more specific response bodies in the future.

## Test plan

- [x] All existing tests updated to assert on new structured body format (error type, description, suggested action)
- [x] New `TestHandleClientCircuitBreakerErrorReturnsDistinctBody` verifies circuit breaker produces distinct body from regular token error
- [x] CONNECT body assertions added to `TestHandleClientTokenErrorCONNECTReturns502` for HTTP/CONNECT symmetry
- [x] `go vet`, `gofmt`, full test suite pass locally
- [x] CI passes on all platforms (linux/amd64, darwin/amd64, darwin/arm64)

https://claude.ai/code/session_01CiXuUVGDGRSPbh6DxvWZSK