### PR TITLE
Upgrade attestation actions to actions/attest

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -46,7 +46,7 @@ jobs:
         run: otool -L spnego-proxy-darwin-${{ matrix.arch }} | grep -i GSS
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: spnego-proxy-darwin-${{ matrix.arch }}
 
@@ -60,7 +60,7 @@ jobs:
           upload-release-assets: false
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@07e74fc4e78d1aad915e867f9a094073a9f71527 # v4.0.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: spnego-proxy-darwin-${{ matrix.arch }}
           sbom-path: spnego-proxy-darwin-${{ matrix.arch }}.sbom.spdx.json
@@ -107,7 +107,7 @@ jobs:
         run: file spnego-proxy-linux-amd64
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: spnego-proxy-linux-amd64
 
@@ -121,7 +121,7 @@ jobs:
           upload-release-assets: false
 
       - name: Attest SBOM
-        uses: actions/attest-sbom@07e74fc4e78d1aad915e867f9a094073a9f71527 # v4.0.0
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-path: spnego-proxy-linux-amd64
           sbom-path: spnego-proxy-linux-amd64.sbom.spdx.json


### PR DESCRIPTION
## Summary

- Replaces deprecated `actions/attest-build-provenance` and `actions/attest-sbom` with the unified `actions/attest@v4.1.0` in `build-release.yml`
- As of v4, both deprecated actions are merely wrappers around `actions/attest` and are no longer maintained independently

## Changes

4 action references updated across `build-macos` and `build-linux` jobs:
- 2x `actions/attest-build-provenance` → `actions/attest` (provenance is the default mode)
- 2x `actions/attest-sbom` → `actions/attest` with `sbom-path` parameter

No permission or parameter changes required.

Closes #150

## Test plan

- [ ] Verify CI workflows pass on this branch
- [ ] Confirm attestations are still generated correctly on a tag push (can be tested with a pre-release tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)