### PR TITLE
Use sync.WaitGroup.Go() for Go 1.25 modernization

### DIFF
--- a/circuit_breaker_test.go
+++ b/circuit_breaker_test.go
@@ -165,12 +165,10 @@ func TestCircuitBreakerHalfOpenRejectsConcurrentRequests(t *testing.T) {
 	errs := make([]error, concurrency)
 	tokens := make([]string, concurrency)
 	var wg sync.WaitGroup
-	wg.Add(concurrency)
 	for i := range concurrency {
-		go func(idx int) {
-			defer wg.Done()
-			tokens[idx], errs[idx] = cb.GetToken()
-		}(i)
+		wg.Go(func() {
+			tokens[i], errs[i] = cb.GetToken()
+		})
 	}
 	wg.Wait()
 

--- a/harness_test.go
+++ b/harness_test.go
@@ -61,8 +61,7 @@ func NewMockUpstreamProxy(t *testing.T, responseFunc func(*http.Request) *http.R
 		responseFunc: responseFunc,
 		closed:       make(chan struct{}),
 	}
-	m.wg.Add(1)
-	go m.acceptLoop()
+	m.wg.Go(m.acceptLoop)
 	return m
 }
 
@@ -78,7 +77,6 @@ func defaultMockResponse(_ *http.Request) *http.Response {
 }
 
 func (m *MockUpstreamProxy) acceptLoop() {
-	defer m.wg.Done()
 	for {
 		conn, err := m.listener.Accept()
 		if err != nil {
@@ -89,13 +87,11 @@ func (m *MockUpstreamProxy) acceptLoop() {
 			}
 			continue
 		}
-		m.wg.Add(1)
-		go m.handleConn(conn)
+		m.wg.Go(func() { m.handleConn(conn) })
 	}
 }
 
 func (m *MockUpstreamProxy) handleConn(conn net.Conn) {
-	defer m.wg.Done()
 	defer func() { _ = conn.Close() }()
 
 	reader := bufio.NewReader(conn)
@@ -226,13 +222,11 @@ func NewProxyUnderTest(t *testing.T, upstream string) *ProxyUnderTest {
 		},
 		closed: make(chan struct{}),
 	}
-	p.wg.Add(1)
-	go p.acceptLoop()
+	p.wg.Go(p.acceptLoop)
 	return p
 }
 
 func (p *ProxyUnderTest) acceptLoop() {
-	defer p.wg.Done()
 	for {
 		conn, err := p.listener.Accept()
 		if err != nil {
@@ -243,11 +237,9 @@ func (p *ProxyUnderTest) acceptLoop() {
 			}
 			continue
 		}
-		p.wg.Add(1)
-		go func() {
-			defer p.wg.Done()
+		p.wg.Go(func() {
 			handleClient(conn, p.getConfig())
-		}()
+		})
 	}
 }
 

--- a/hop_by_hop_test.go
+++ b/hop_by_hop_test.go
@@ -151,9 +151,7 @@ func TestE2_RFC9112_InvalidContentLengthInResponse(t *testing.T) {
 	defer func() { _ = rawUpstream.Close() }()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		conn, err := rawUpstream.Accept()
 		if err != nil {
 			return
@@ -168,7 +166,7 @@ func TestE2_RFC9112_InvalidContentLengthInResponse(t *testing.T) {
 			"\r\n" +
 			"body"
 		_, _ = conn.Write([]byte(resp))
-	}()
+	})
 	t.Cleanup(wg.Wait)
 
 	proxy := NewProxyUnderTest(t, rawUpstream.Addr().String())
@@ -257,9 +255,7 @@ func TestE1_RFC9112_ResponseTEAndCLConflictRemovesCL(t *testing.T) {
 	defer func() { _ = rawUpstream.Close() }()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		conn, err := rawUpstream.Accept()
 		if err != nil {
 			return
@@ -275,7 +271,7 @@ func TestE1_RFC9112_ResponseTEAndCLConflictRemovesCL(t *testing.T) {
 			"\r\n" +
 			"5\r\nhello\r\n0\r\n\r\n"
 		_, _ = conn.Write([]byte(resp))
-	}()
+	})
 	t.Cleanup(wg.Wait)
 
 	proxy := NewProxyUnderTest(t, rawUpstream.Addr().String())
@@ -500,9 +496,7 @@ func TestE2_RFC9112_MultipleDifferingCLInResponse(t *testing.T) {
 	defer func() { _ = rawUpstream.Close() }()
 
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		conn, err := rawUpstream.Accept()
 		if err != nil {
 			return
@@ -517,7 +511,7 @@ func TestE2_RFC9112_MultipleDifferingCLInResponse(t *testing.T) {
 			"\r\n" +
 			"hello"
 		_, _ = conn.Write([]byte(resp))
-	}()
+	})
 	t.Cleanup(wg.Wait)
 
 	proxy := NewProxyUnderTest(t, rawUpstream.Addr().String())

--- a/main.go
+++ b/main.go
@@ -552,11 +552,9 @@ func closeWrite(conn net.Conn) {
 }
 
 // forwardHalf copies data from src to dst, calling CloseWrite on dst when
-// done. It logs the start, completion, and any errors. wg.Done is deferred
-// so callers can use a WaitGroup to synchronise the two halves of a
-// bidirectional forwarding pair.
-func forwardHalf(wg *sync.WaitGroup, dst net.Conn, src io.Reader, fromAddr, toAddr net.Addr) {
-	defer wg.Done()
+// done. It logs the start, completion, and any errors. Callers use
+// wg.Go to launch forwardHalf so the WaitGroup is managed automatically.
+func forwardHalf(dst net.Conn, src io.Reader, fromAddr, toAddr net.Addr) {
 	defer closeWrite(dst)
 	slog.Debug("forward start", "from", fromAddr, "to", toAddr)
 	defer slog.Debug("forward done", "from", fromAddr, "to", toAddr)
@@ -695,11 +693,9 @@ func handleClient(conn net.Conn, cfg ProxyConfig) {
 	}
 
 	var wg sync.WaitGroup
-	wg.Add(2)
-	go forwardHalf(&wg, proxyConn, reqReader, conn.RemoteAddr(), proxyConn.RemoteAddr())
+	wg.Go(func() { forwardHalf(proxyConn, reqReader, conn.RemoteAddr(), proxyConn.RemoteAddr()) })
 	// Upstream→client: parse response headers to inject Via, then relay body.
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		defer closeWrite(conn)
 		slog.Debug("forward start", "from", proxyConn.RemoteAddr(), "to", conn.RemoteAddr())
 		defer slog.Debug("forward done", "from", proxyConn.RemoteAddr(), "to", conn.RemoteAddr())
@@ -716,7 +712,7 @@ func handleClient(conn net.Conn, cfg ProxyConfig) {
 			slog.Error("forward error", "error", err, "from", proxyConn.RemoteAddr(), "to", conn.RemoteAddr())
 			return
 		}
-	}()
+	})
 	wg.Wait()
 }
 
@@ -756,9 +752,8 @@ func handleConnectTunnel(conn, proxyConn net.Conn, reqReader *bufio.Reader, req 
 
 	slog.Debug("CONNECT tunnel established", "client_addr", clientAddr, "upstream_addr", proxyConn.RemoteAddr())
 	var wg sync.WaitGroup
-	wg.Add(2)
-	go forwardHalf(&wg, proxyConn, reqReader, conn.RemoteAddr(), proxyConn.RemoteAddr())
-	go forwardHalf(&wg, conn, upstreamReader, proxyConn.RemoteAddr(), conn.RemoteAddr())
+	wg.Go(func() { forwardHalf(proxyConn, reqReader, conn.RemoteAddr(), proxyConn.RemoteAddr()) })
+	wg.Go(func() { forwardHalf(conn, upstreamReader, proxyConn.RemoteAddr(), conn.RemoteAddr()) })
 	wg.Wait()
 }
 
@@ -860,11 +855,9 @@ func main() {
 				slog.Error("accept error", "error", err)
 				continue
 			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				handleClient(conn, cfg)
-			}()
+			})
 		}
 	}()
 

--- a/main_test.go
+++ b/main_test.go
@@ -286,11 +286,9 @@ func TestShutdownDrainsInFlightConnections(t *testing.T) {
 				}
 				continue
 			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				handleClient(conn, cfg)
-			}()
+			})
 		}
 	}()
 
@@ -389,11 +387,9 @@ func TestShutdownDrainTimeout(t *testing.T) {
 				}
 				continue
 			}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+			wg.Go(func() {
 				handleClient(conn, cfg)
-			}()
+			})
 		}
 	}()
 

--- a/protocol_edge_cases_test.go
+++ b/protocol_edge_cases_test.go
@@ -316,33 +316,30 @@ func TestI1I2_ConcurrentConnectionsClosed(t *testing.T) {
 	errs := make(chan error, numClients)
 
 	for i := range numClients {
-		wg.Add(1)
-		go func(idx int) {
-			defer wg.Done()
-
+		wg.Go(func() {
 			conn, err := net.DialTimeout("tcp", proxy.Addr(), 5*time.Second)
 			if err != nil {
-				errs <- fmt.Errorf("client %d: dial: %w", idx, err)
+				errs <- fmt.Errorf("client %d: dial: %w", i, err)
 				return
 			}
 			defer func() { _ = conn.Close() }()
 
-			raw := fmt.Sprintf("GET http://example.com/concurrent/%d HTTP/1.0\r\nHost: example.com\r\n\r\n", idx)
+			raw := fmt.Sprintf("GET http://example.com/concurrent/%d HTTP/1.0\r\nHost: example.com\r\n\r\n", i)
 			if _, writeErr := conn.Write([]byte(raw)); writeErr != nil {
-				errs <- fmt.Errorf("client %d: write: %w", idx, writeErr)
+				errs <- fmt.Errorf("client %d: write: %w", i, writeErr)
 				return
 			}
 
 			resp, readErr := http.ReadResponse(bufio.NewReader(conn), nil)
 			if readErr != nil {
-				errs <- fmt.Errorf("client %d: read response: %w", idx, readErr)
+				errs <- fmt.Errorf("client %d: read response: %w", i, readErr)
 				return
 			}
 			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 
 			if resp.StatusCode != http.StatusOK {
-				errs <- fmt.Errorf("client %d: want 200 OK, got %d", idx, resp.StatusCode)
+				errs <- fmt.Errorf("client %d: want 200 OK, got %d", i, resp.StatusCode)
 				return
 			}
 
@@ -351,9 +348,9 @@ func TestI1I2_ConcurrentConnectionsClosed(t *testing.T) {
 			buf := make([]byte, 1)
 			n, connErr := conn.Read(buf)
 			if n > 0 || connErr == nil {
-				errs <- fmt.Errorf("client %d: expected closed connection, got %d bytes, err=%w", idx, n, connErr)
+				errs <- fmt.Errorf("client %d: expected closed connection, got %d bytes, err=%w", i, n, connErr)
 			}
-		}(i)
+		})
 	}
 
 	wg.Wait()


### PR DESCRIPTION
## Summary

- Converts all `wg.Add(1); go func() { defer wg.Done(); ... }()` patterns to Go 1.25's `wg.Go(func() { ... })`
- Simplifies `forwardHalf` by removing its `*sync.WaitGroup` parameter (callers now use `wg.Go`)
- Net result: 36 insertions, 66 deletions across 6 files

## Changes

- **main.go**: Updated `forwardHalf` signature and comment, converted 3 call sites (`handleClient`, `handleConnectTunnel`, `main`)
- **harness_test.go**: Converted `MockUpstreamProxy` and `ProxyUnderTest` goroutine management
- **hop_by_hop_test.go**: Converted 3 upstream mock goroutines
- **circuit_breaker_test.go**: Converted concurrent token acquisition loop
- **protocol_edge_cases_test.go**: Converted concurrent client test loop
- **main_test.go**: Converted 2 accept loop patterns

Closes #151

## Test plan

- [x] `CGO_ENABLED=0 go build ./...` passes
- [x] `CGO_ENABLED=0 go test ./...` passes
- [ ] CI workflows pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)