### PR TITLE
docs: record pipelined-bytes smuggling mitigation (v1.2.5)

### DIFF
--- a/docs/http-proxy-standards-requirements.md
+++ b/docs/http-proxy-standards-requirements.md
@@ -609,6 +609,26 @@ Syntax constraints:
 **Level**: MUST
 **Details**: Covered by E1 and E2. This is cross-referenced here for completeness. The proxy must rigorously handle message framing to prevent request smuggling.
 
+#### K4. Per-request validation on persistent connections
+
+> "A proxy MUST NOT forward a request without first determining whether the request is well-formed and whether its framing is unambiguous."
+>
+> — RFC 9112, §11.2 (in spirit; framing rules in §6 apply per request)
+
+**Level**: MUST
+**Details**: When a client sends HTTP requests on a persistent connection (HTTP/1.1 keep-alive), the proxy MUST parse and validate every request independently. Bytes pipelined behind a validated first request MUST NOT be raw-copied onto an already-authenticated upstream connection; they MUST be re-parsed and run through the full hop-by-hop sanitisation and per-request policy pipeline (Via loop, connect-ports, Max-Forwards, forwarding-header injection).
+
+Implemented in `handleClient` (non-CONNECT branch) and `handleDirectHTTP` as of v1.2.5 (PR #216, fix #215). Hop-by-hop sanitisation runs every iteration so a smuggled `Proxy-Authorization` cannot ride an already-authenticated upstream connection (RFC 4559 §5 connection-bound auth context). `handleDirectHTTP` additionally binds the direct TCP connection to the first request's target host; pipelined requests for any other host are rejected with `errMismatchedTarget`.
+
+**Testing strategy**:
+
+- **PoC reproduction**: `TestHandleClientRejectsSmuggledRequest` — client pipelines a forbidden CONNECT behind a valid GET; assert upstream receives only the GET.
+- **Header stripping**: `TestRFC4559_ConnectionBoundAuthSingleTokenAcquisition` — pipelined request with attacker `Proxy-Authorization` is stripped; SPNEGO token acquired once.
+- **Host binding**: `TestHandleDirectHTTPRejectsHostMismatch`.
+- **CONNECT smuggle**: `TestHandleDirectHTTPRejectsSmuggledConnect`.
+- **Loop exit signals**: `TestHandleClientConnectionCloseTerminatesLoop`, `TestI2_RFC9112_RequestConnectionCloseTerminatesKeepAliveLoop`, `TestI1I2_ConnectionClosedAfterResponse`.
+- **Traceability**: RFC 9112 §11.2, RFC 4559 §5, RFC 9110 §11.7.1.
+
 #### K2. CONNECT Port Restriction
 
 > See D4 above.

--- a/docs/threat-model/P4-SECURITY-REVIEW.md
+++ b/docs/threat-model/P4-SECURITY-REVIEW.md
@@ -80,7 +80,7 @@
 ## Positive Security Controls
 
 The codebase demonstrates strong security awareness:
-1. **Request smuggling defenses**: TE/CL conflict resolution per RFC 9112
+1. **Request smuggling defenses**: TE/CL conflict resolution per RFC 9112 §6.1, plus per-request re-validation of pipelined HTTP requests on persistent connections (v1.2.5) closing the buffered-bytes vector on the SPNEGO-authenticated upstream socket
 2. **Hop-by-hop sanitization**: Full RFC 9110 compliance
 3. **Loop detection**: Random pseudonym checked before hop-by-hop stripping
 4. **Circuit breaker**: Prevents account lockout cascading

--- a/docs/threat-model/P5-STRIDE-THREATS.md
+++ b/docs/threat-model/P5-STRIDE-THREATS.md
@@ -37,6 +37,13 @@
 - **Priority**: P1
 - **Mitigated**: sanitizeHopByHop resolves TE/CL conflicts per RFC 9112
 
+### T-T-P-002-002: Request smuggling via pipelined bytes on persistent connection
+- **Element**: P-002 (HTTP Request Parser)
+- **STRIDE**: Tampering
+- **CWE**: CWE-444
+- **Priority**: P1
+- **Mitigated** (v1.2.5, PR #216, fix #215): handleClient and handleDirectHTTP run a keep-alive loop that re-parses every pipelined request through prepareForwardRequest. Bytes pipelined behind a validated first request are no longer raw-copied onto the SPNEGO-authenticated upstream connection; each subsequent request runs the full validation pipeline (Via loop, connect-ports, Max-Forwards, hop-by-hop sanitisation including Proxy-Authorization stripping). handleDirectHTTP additionally binds the direct TCP connection to the first request's target host.
+
 ### T-I-P-005-001: SPNEGO token exposed in cleartext
 - **Element**: P-005 (SPNEGO Token Injector)
 - **STRIDE**: Information Disclosure
@@ -92,7 +99,7 @@
 ## Key Observations
 
 1. **No P0 (Critical) threats**: The codebase has strong security controls that mitigate the most severe scenarios
-2. **Mitigated P1 threats**: Request smuggling (T-T-P-002-001) and response smuggling (T-T-P-007-001) are effectively mitigated by existing code
+2. **Mitigated P1 threats**: Request smuggling via TE/CL (T-T-P-002-001), pipelined-bytes smuggling on persistent connections (T-T-P-002-002, fixed v1.2.5), and response smuggling (T-T-P-007-001) are effectively mitigated by current code
 3. **Architectural P1 threats**: Lack of client auth and plaintext transport are design decisions, not bugs
 4. **Many P3 threats**: In-process data flows and repudiation threats are low-risk theoretical concerns
 5. **Circuit breaker is dual-edged**: Protects against account lockout but can be weaponized for DoS

--- a/docs/threat-model/SPNEGO-PROXY-RISK-ASSESSMENT-REPORT.md
+++ b/docs/threat-model/SPNEGO-PROXY-RISK-ASSESSMENT-REPORT.md
@@ -65,7 +65,7 @@
 5. **Raw relay bypasses validation**: Unparseable upstream responses trigger a raw byte relay path that bypasses Content-Length validation, Via header injection, and auth header stripping (VR-004, CVSS 5.3).
 6. **CONNECT allows all ports by default**: Without explicit `-connect-ports` configuration, the proxy tunnels to any port on any host through the upstream (VR-005, CVSS 5.3).
 7. **No idle timeout on tunnels**: CONNECT tunnels persist indefinitely once established, enabling connection slot exhaustion (VR-006, CVSS 5.3).
-8. **Request smuggling defenses are effective but unmonitored**: TE/CL conflict resolution is correctly implemented per RFC 9112, but no logging detects smuggling attempts (VR-008, CVSS 5.9).
+8. **Request smuggling defenses are effective but unmonitored**: TE/CL conflict resolution per RFC 9112 §6.1, plus per-request re-validation of pipelined HTTP requests on persistent connections (v1.2.5, PR #216, closes pipelined-bytes vector), are correctly implemented; no logging detects smuggling attempts (VR-008, CVSS 5.9).
 9. **CGo boundary is bounds-checked but not fuzz-tested**: C code uses fixed-size buffers with `snprintf`, but no fuzz testing validates the Go-C boundary (VR-011, CVSS 5.0).
 10. **Security event logging lacks classification**: Structured JSON logging exists but security events are not distinguished from operational logs, limiting forensic capability (VR-012, CVSS 3.1).
 
@@ -478,10 +478,10 @@ printf 'CONNECT internal-host:22 HTTP/1.1\r\nHost: internal-host:22\r\n\r\n' | \
 - **Status**: Theoretical (Mitigated)
 - **STRIDE**: T
 - **CWE**: CWE-444 (HTTP Request/Response Smuggling)
-- **Source Threats**: T-T-P-002-001, T-T-P-007-001
+- **Source Threats**: T-T-P-002-001, T-T-P-002-002, T-T-P-007-001
 - **Location**: main.go (P-002, P-007), Trust Boundary TB-001
 
-**Detailed Analysis**: The proxy implements TE/CL conflict resolution per RFC 9112 in both request (sanitizeHopByHop) and response (readUpstreamResponse) paths. When both Transfer-Encoding and Content-Length are present, Content-Length is removed. This is the correct defense, but novel smuggling variants could potentially bypass it.
+**Detailed Analysis**: The proxy implements TE/CL conflict resolution per RFC 9112 in both request (sanitizeHopByHop) and response (readUpstreamResponse) paths. When both Transfer-Encoding and Content-Length are present, Content-Length is removed. As of v1.2.5 (PR #216, fix #215), the proxy also re-parses and re-validates every request on a persistent client connection through prepareForwardRequest before forwarding to the upstream, closing the pipelined-bytes vector where bytes sent behind a validated first request were previously raw-copied onto the SPNEGO-authenticated upstream socket. These are the correct defenses, but novel smuggling variants could potentially bypass them.
 
 **Root Cause**: HTTP desynchronization attacks evolve continuously. The current defenses are comprehensive but may not cover future variants.
 

--- a/docs/threat-model/SPNEGO-PROXY-RISK-INVENTORY.md
+++ b/docs/threat-model/SPNEGO-PROXY-RISK-INVENTORY.md
@@ -183,10 +183,10 @@
 - **CAPEC**: CAPEC-33
 - **Location**: main.go (P-002, P-007)
 - **Trust Boundary**: TB-001
-- **Description**: The proxy implements TE/CL conflict resolution per RFC 9112. This is the correct defense, but novel smuggling variants could potentially bypass it.
-- **Threat Refs**: T-T-P-002-001, T-T-P-007-001
+- **Description**: The proxy implements TE/CL conflict resolution per RFC 9112 and (as of v1.2.5) re-validates every pipelined request on a persistent connection so bytes sent behind a validated first request cannot be raw-copied onto the SPNEGO-authenticated upstream connection. These are the correct defenses, but novel smuggling variants could potentially bypass them.
+- **Threat Refs**: T-T-P-002-001, T-T-P-002-002, T-T-P-007-001
 - **Finding Refs**: F-P1-005
-- **Validation**: Theoretical (Mitigated) -- code implements RFC 9112 defenses; no known bypass found
+- **Validation**: Theoretical (Mitigated) -- code implements RFC 9112 §6.1 (TE/CL) and §11.2 (per-request re-parse) defenses; no known bypass. Pipelined-bytes vector closed in v1.2.5 (PR #216, fix #215).
 - **Mitigation**: MIT-008 (Harden request smuggling defenses with monitoring)
 
 ---


### PR DESCRIPTION
## Summary

Follow-up to PR #216 (security fix #215, released as v1.2.5). The fix added a new defence — per-request re-parsing of pipelined requests on a persistent connection — but the threat model and RFC compliance matrix only documented the older TE/CL conflict defence. This PR closes that gap.

Documents updated:

- `docs/http-proxy-standards-requirements.md`: new **K4 — Per-request validation on persistent connections** entry under Group K (Security and Access Control). Cites RFC 9112 §11.2, RFC 4559 §5, and RFC 9110 §11.7.1, and lists the regression tests added in v1.2.5.
- `docs/threat-model/P5-STRIDE-THREATS.md`: new **T-T-P-002-002** threat entry (pipelined-bytes smuggling, mitigated v1.2.5); refreshed the "Mitigated P1 threats" key observation.
- `docs/threat-model/P4-SECURITY-REVIEW.md`: extended the "Request smuggling defenses" positive control to name the buffered-bytes vector closure.
- `docs/threat-model/SPNEGO-PROXY-RISK-INVENTORY.md` (VR-008): added the new threat ref and mitigation note.
- `docs/threat-model/SPNEGO-PROXY-RISK-ASSESSMENT-REPORT.md` (VR-008 + executive summary item #8): same.

No code changes. No version bump (conventional commit type `docs:` — does not trigger auto-tag, per CLAUDE.md).

## Test plan

- [x] `git diff --stat` — 5 files, 35 insertions, 8 deletions.
- [ ] CI: `lint-markdown` should pass (threat-model files are ignored by `.markdownlint-cli2.yaml`; only `docs/http-proxy-standards-requirements.md` is linted, and the addition follows the existing K-group format).
- [ ] No Go changes; build/test/lint should be unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)