### PR TITLE
feat: enforce RFC framing conformance on upstream responses

### DIFF
--- a/docs/http-proxy-standards-requirements.md
+++ b/docs/http-proxy-standards-requirements.md
@@ -416,6 +416,79 @@ Defined error types relevant to spnego-proxy:
 - **White-box integration test**: Mock upstream sends a response with an obs-fold header (`Header: value\r\n continued`). Assert the proxy either normalizes it to `Header: value continued` or returns 502.
 - **Traceability**: RFC 9112 §5.2.
 
+#### E4. Non-chunked Transfer-Encoding on Inbound Request
+
+> "If a Transfer-Encoding header field is present in a request and the chunked transfer coding is not the final encoding, the message body length cannot be determined reliably; the server MUST respond with the 400 (Bad Request) status code and then close the connection."
+>
+> — RFC 9112, §6.1
+
+**Level**: MUST
+**Details**: A request whose `Transfer-Encoding` does not end in `chunked` (e.g. `gzip` alone, or `chunked, gzip`) has unknown framing. The proxy MUST reject it and MUST NOT forward.
+
+**Testing strategy**:
+
+- **White-box integration test** (`TestE3_RFC9112_NonChunkedTransferEncoding_Request` in `framing_conformance_test.go`): raw request lines with `Transfer-Encoding: gzip` and `Transfer-Encoding: chunked, gzip` → assert 400/502 response and zero forwarded requests at the upstream.
+- **Traceability**: RFC 9112 §6.1.
+
+#### E5. Request-side Content-Length Anomalies
+
+> "A recipient MUST anticipate the possibility of multiple Content-Length header fields ... If at least one such field is present, but with an invalid value, ... the recipient MUST treat the message as invalid."
+>
+> — RFC 9112, §6.1
+
+**Level**: MUST
+**Details**: Request-side `Content-Length` values that are negative, hex-prefixed, non-numeric, prefixed with `+`, OWS-only, or supplied as multiple differing values must all be rejected before the request is forwarded.
+
+**Testing strategy**:
+
+- **White-box integration test** (`TestE4_RFC9112_RequestContentLengthAnomalies`): matrix of malformed CL values via raw socket → assert 400/502 response and zero forwarded requests.
+- **Traceability**: RFC 9112 §6.1.
+
+#### E6. Forbidden Control Octets in Upstream Response Headers
+
+> "Field values containing CR, LF, or NUL characters are invalid and dangerous, due to the varying ways that implementations might parse and interpret those characters."
+>
+> — RFC 9110, §5.5
+
+**Level**: MUST
+**Details**: After parsing the upstream response, every field name must match the RFC 9110 §5.1 `tchar` production and every field value must contain only `field-vchar / SP / HTAB / obs-text` octets. Bare CR, bare LF, NUL, and other ASCII control characters (0x00–0x08, 0x0A–0x1F, 0x7F) in a value indicate a malformed emitter or a response-splitting attempt; the proxy MUST close the connection and return 502 `http_protocol_error`.
+
+**Defence-in-depth**: Go's `textproto` parser already splits on properly-framed CRLF, so a clean two-header payload like `X-Evil: foo\r\nInjected: 1\r\n` parses into two distinct, well-formed headers and is indistinguishable from an intentional dual-header response. This validator catches the variants that survive parsing: bare CR mid-value, NUL bytes, BEL, and other C0 controls.
+
+**Testing strategy**:
+
+- **White-box integration test** (`TestE5_RFC9110_ResponseHeaderControlOctetsRejected`): raw upstream emits headers with bare CR, NUL, and BEL inside values → assert 502 with `http_protocol_error` and no injected header on the client.
+- **Unit test** (`TestValidateResponseHeaderBytes_Unit`): table-driven coverage of acceptable values (clean ASCII, tab, obs-text UTF-8 bytes) and rejected values (bare CR/LF, NUL, BEL, DEL, malformed names).
+- **Traceability**: RFC 9110 §5.5, RFC 9112 §11.1.
+
+#### E7. Chunk-extension Forwarding Safety
+
+> "A recipient MUST be able to parse the chunked transfer coding ... A recipient MUST ignore unrecognized chunk extensions."
+>
+> — RFC 9112, §7.1.1
+
+**Level**: MUST
+**Details**: The proxy MUST relay a chunked request body whose chunks carry chunk-extensions without misframing the message. Extensions MAY be dropped on egress.
+
+**Testing strategy**:
+
+- **White-box integration test** (`TestE6_RFC9112_ChunkExtensionsForwardedSafely`): chunked POST with `5;ext=foo\r\nhello\r\n0\r\n\r\n` → upstream receives the intact body `hello`.
+- **Traceability**: RFC 9112 §7.1.1.
+
+#### E8. Chunked Trailer Consistency
+
+> "When a chunked message containing a non-empty trailer is received, the recipient MAY process the fields as if they were appended to the message's header section. ... A proxy MUST forward a non-empty trailer in a downstream message only if it advertised the trailer field names in the Trailer header field."
+>
+> — RFC 9112, §7.1.2
+
+**Level**: MUST
+**Details**: If the proxy advertises trailer fields via the `Trailer` response header, it MUST deliver them; if it strips trailers, it MUST also strip the `Trailer` advertisement so downstream recipients do not wait for trailers that will never arrive.
+
+**Testing strategy**:
+
+- **White-box integration test** (`TestE7_RFC9112_ChunkedResponseWithTrailerConsistent`): upstream emits a chunked response declaring `Trailer: X-Checksum` and supplies the trailer. Assert that whenever `Trailer` survives in the response headers, the corresponding trailer value is present in `resp.Trailer`.
+- **Traceability**: RFC 9112 §7.1.2.
+
 ---
 
 ### Group F: Expect / 100-Continue Handling
@@ -760,6 +833,11 @@ Per RFC 9113, §8.2.2: "intermediaries SHOULD also remove other connection-speci
 | E1 | TE/CL conflict resolution | MUST |
 | E2 | Invalid Content-Length → 502 | MUST |
 | E3 | obs-fold handling | MUST |
+| E4 | Non-chunked Transfer-Encoding on request → 400 | MUST |
+| E5 | Request-side Content-Length anomalies → 400 | MUST |
+| E6 | Control octets in upstream response headers → 502 | MUST |
+| E7 | Chunk-extensions forwarded without misframing | MUST |
+| E8 | Chunked trailer consistency | MUST |
 | F1 | Forward Expect: 100-continue | MUST |
 | F2 | Don't forward 100 to HTTP/1.0 clients | MUST NOT |
 | G1 | Max-Forwards for TRACE/OPTIONS | MUST |

--- a/framing_conformance_test.go
+++ b/framing_conformance_test.go
@@ -1,15 +1,11 @@
 package main
 
 import (
-	"bufio"
 	"bytes"
 	"io"
-	"net"
 	"net/http"
 	"strings"
-	"sync"
 	"testing"
-	"time"
 )
 
 // ---------------------------------------------------------------------------
@@ -137,47 +133,11 @@ func TestE5_RFC9110_ResponseHeaderControlOctetsRejected(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			rawUpstream, err := net.Listen("tcp", "127.0.0.1:0")
-			if err != nil {
-				t.Fatalf("listen: %v", err)
-			}
-			defer func() { _ = rawUpstream.Close() }()
-
-			var wg sync.WaitGroup
-			wg.Go(func() {
-				conn, aerr := rawUpstream.Accept()
-				if aerr != nil {
-					return
-				}
-				defer func() { _ = conn.Close() }()
-				reader := bufio.NewReader(conn)
-				_, _ = http.ReadRequest(reader)
-				resp := "HTTP/1.1 200 OK\r\n" +
-					tc.respHeaders +
-					"Content-Length: 0\r\n" +
-					"\r\n"
-				_, _ = conn.Write([]byte(resp))
-			})
-			t.Cleanup(wg.Wait)
-
-			proxy := NewProxyUnderTest(t, rawUpstream.Addr().String())
-			defer proxy.Close()
-
-			conn, err := net.DialTimeout("tcp", proxy.Addr(), 5*time.Second)
-			if err != nil {
-				t.Fatalf("dial proxy: %v", err)
-			}
-			defer func() { _ = conn.Close() }()
-
-			req, _ := http.NewRequest("GET", "http://example.com/e5", nil)
-			if err := req.WriteProxy(conn); err != nil {
-				t.Fatalf("write request: %v", err)
-			}
-
-			resp, err := http.ReadResponse(bufio.NewReader(conn), req)
-			if err != nil {
-				t.Fatalf("read response: %v", err)
-			}
+			canned := "HTTP/1.1 200 OK\r\n" +
+				tc.respHeaders +
+				"Content-Length: 0\r\n" +
+				"\r\n"
+			resp := rawCannedUpstreamRoundTrip(t, "/e5", canned)
 			defer func() { _ = resp.Body.Close() }()
 
 			assertStatusCode(t, resp, http.StatusBadGateway)
@@ -237,18 +197,6 @@ func TestE5_RFC9110_RequestHeaderCRLFNotForwarded(t *testing.T) {
 func TestE6_RFC9112_ChunkExtensionsForwardedSafely(t *testing.T) {
 	const wantBody = "hello"
 
-	upstream := NewMockUpstreamProxy(t, nil)
-	defer upstream.Close()
-
-	proxy := NewProxyUnderTest(t, upstream.Addr())
-	defer proxy.Close()
-
-	conn, err := net.DialTimeout("tcp", proxy.Addr(), 5*time.Second)
-	if err != nil {
-		t.Fatalf("dial proxy: %v", err)
-	}
-	defer func() { _ = conn.Close() }()
-
 	// Chunked POST with a chunk-extension on the data chunk.
 	raw := "POST http://example.com/e6 HTTP/1.1\r\n" +
 		"Host: example.com\r\n" +
@@ -257,18 +205,10 @@ func TestE6_RFC9112_ChunkExtensionsForwardedSafely(t *testing.T) {
 		"5;ext=foo\r\nhello\r\n" +
 		"0\r\n" +
 		"\r\n"
-	if _, err := conn.Write([]byte(raw)); err != nil {
-		t.Fatalf("write raw request: %v", err)
-	}
-
-	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
-	if err != nil {
-		t.Fatalf("read response: %v", err)
-	}
+	resp, reqs := proxyRawRoundTrip(t, raw)
 	defer func() { _ = resp.Body.Close() }()
 	assertStatusCode(t, resp, http.StatusOK)
 
-	reqs := upstream.Requests()
 	if len(reqs) != 1 {
 		t.Fatalf("upstream received %d requests, want 1", len(reqs))
 	}
@@ -328,55 +268,19 @@ func TestValidateResponseHeaderBytes_Unit(t *testing.T) {
 // terminator is reached, body is correctly delimited).
 
 func TestE7_RFC9112_ChunkedResponseWithTrailerConsistent(t *testing.T) {
-	rawUpstream, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen: %v", err)
-	}
-	defer func() { _ = rawUpstream.Close() }()
-
-	var wg sync.WaitGroup
-	wg.Go(func() {
-		conn, aerr := rawUpstream.Accept()
-		if aerr != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		reader := bufio.NewReader(conn)
-		_, _ = http.ReadRequest(reader)
-		// Chunked response carrying a Trailer header + actual trailer
-		// field after the zero chunk.
-		resp := "HTTP/1.1 200 OK\r\n" +
-			"Transfer-Encoding: chunked\r\n" +
-			"Trailer: X-Checksum\r\n" +
-			"\r\n" +
-			"5\r\nhello\r\n" +
-			"0\r\n" +
-			"X-Checksum: abc123\r\n" +
-			"\r\n"
-		_, _ = conn.Write([]byte(resp))
-	})
-	t.Cleanup(wg.Wait)
-
-	proxy := NewProxyUnderTest(t, rawUpstream.Addr().String())
-	defer proxy.Close()
-
-	conn, err := net.DialTimeout("tcp", proxy.Addr(), 5*time.Second)
-	if err != nil {
-		t.Fatalf("dial proxy: %v", err)
-	}
-	defer func() { _ = conn.Close() }()
-
-	req, _ := http.NewRequest("GET", "http://example.com/e7", nil)
-	if err := req.WriteProxy(conn); err != nil {
-		t.Fatalf("write request: %v", err)
-	}
-
+	// Chunked response carrying a Trailer header + actual trailer field
+	// after the zero chunk.
+	canned := "HTTP/1.1 200 OK\r\n" +
+		"Transfer-Encoding: chunked\r\n" +
+		"Trailer: X-Checksum\r\n" +
+		"\r\n" +
+		"5\r\nhello\r\n" +
+		"0\r\n" +
+		"X-Checksum: abc123\r\n" +
+		"\r\n"
 	// Read the full response, including body, so we can assert framing
 	// is intact (no truncation, no leftover trailer bytes on the wire).
-	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
-	if err != nil {
-		t.Fatalf("read response: %v", err)
-	}
+	resp := rawCannedUpstreamRoundTrip(t, "/e7", canned)
 	defer func() { _ = resp.Body.Close() }()
 	assertStatusCode(t, resp, http.StatusOK)
 

--- a/framing_conformance_test.go
+++ b/framing_conformance_test.go
@@ -1,0 +1,402 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// E3 — RFC 9112 §6.1: Non-final / non-chunked Transfer-Encoding on request
+// ---------------------------------------------------------------------------
+//
+// RFC 9112 §6.1: when Transfer-Encoding is present and the final coding is
+// NOT "chunked", the message body framing is unknown to the recipient and
+// the connection MUST be closed after receiving the request. A forward
+// proxy MUST reject such a request because it cannot reliably forward an
+// unframed body.
+//
+// Variants:
+//   - "Transfer-Encoding: gzip"            (no chunked at all)
+//   - "Transfer-Encoding: chunked, gzip"   (chunked not final)
+//   - "Transfer-Encoding: gzip, chunked"   (final IS chunked → acceptable
+//                                            framing, but RFC 9112 also says
+//                                            a proxy MAY reject for caution;
+//                                            we expect rejection here too).
+
+func TestE3_RFC9112_NonChunkedTransferEncoding_Request(t *testing.T) {
+	tests := []struct {
+		name string
+		te   string
+	}{
+		{name: "no_chunked_at_all", te: "gzip"},
+		{name: "chunked_not_final", te: "chunked, gzip"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := "POST http://example.com/e3 HTTP/1.1\r\n" +
+				"Host: example.com\r\n" +
+				"Transfer-Encoding: " + tc.te + "\r\n" +
+				"\r\n"
+			resp, reqs := proxyRawRoundTrip(t, raw)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusBadRequest && resp.StatusCode != http.StatusBadGateway {
+				t.Errorf("status: want 400 or 502, got %d", resp.StatusCode)
+			}
+			if ps := resp.Header.Get("Proxy-Status"); !strings.Contains(ps, "http_") {
+				t.Errorf("expected http_* Proxy-Status token, got %q", ps)
+			}
+			if len(reqs) != 0 {
+				t.Errorf("upstream received %d requests; expected 0 (request must not be forwarded)", len(reqs))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// E4 — RFC 9112 §6.1: Request-side Content-Length anomalies
+// ---------------------------------------------------------------------------
+//
+// Mirrors the response-side TestE2_RFC9112_MultipleDifferingCLInResponse but
+// on the inbound request: a forward proxy MUST reject (not silently
+// normalise) malformed Content-Length values per RFC 9112 §6.1.
+
+func TestE4_RFC9112_RequestContentLengthAnomalies(t *testing.T) {
+	tests := []struct {
+		name string
+		cl   string // raw CL header line — may include duplicate header lines
+	}{
+		{name: "negative", cl: "Content-Length: -1\r\n"},
+		{name: "plus_prefix", cl: "Content-Length: +5\r\n"},
+		{name: "hex_prefix", cl: "Content-Length: 0x05\r\n"},
+		{name: "duplicate_differing", cl: "Content-Length: 5\r\nContent-Length: 7\r\n"},
+		{name: "non_numeric", cl: "Content-Length: abc\r\n"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := "POST http://example.com/e4 HTTP/1.1\r\n" +
+				"Host: example.com\r\n" +
+				tc.cl +
+				"\r\n"
+			resp, reqs := proxyRawRoundTrip(t, raw)
+			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusBadRequest && resp.StatusCode != http.StatusBadGateway {
+				t.Errorf("status: want 400 or 502, got %d", resp.StatusCode)
+			}
+			if len(reqs) != 0 {
+				t.Errorf("upstream received %d requests; expected 0", len(reqs))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// E5 — RFC 9110 §5.5 / RFC 9112 §11.1: forbidden control octets in response
+// header values are rejected (response-splitting defence-in-depth).
+// ---------------------------------------------------------------------------
+//
+// A forward proxy MUST NOT relay header values that contain CR, LF, NUL or
+// other ASCII control characters. Go's textproto parser splits on CRLF and
+// would expose a clean "X-Evil: foo\r\nInjected: 1\r\n" payload as two
+// distinct, well-formed headers — that case is indistinguishable from an
+// intentional dual-header response and cannot be detected after parsing.
+//
+// What IS detectable post-parse is a header value containing a bare CR
+// (no following LF) or a NUL/other control octet inside the value. These
+// variants survive the textproto pass and reach the validator added in
+// readUpstreamResponse.
+
+func TestE5_RFC9110_ResponseHeaderControlOctetsRejected(t *testing.T) {
+	tests := []struct {
+		name        string
+		respHeaders string // raw header lines (must end each line with \r\n)
+	}{
+		{
+			name:        "bare_CR_in_value",
+			respHeaders: "X-Evil: foo\rInjected: 1\r\n",
+		},
+		{
+			name:        "NUL_in_value",
+			respHeaders: "X-Evil: foo\x00bar\r\n",
+		},
+		{
+			name:        "bel_control_in_value",
+			respHeaders: "X-Evil: foo\x07bar\r\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			rawUpstream, err := net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen: %v", err)
+			}
+			defer func() { _ = rawUpstream.Close() }()
+
+			var wg sync.WaitGroup
+			wg.Go(func() {
+				conn, aerr := rawUpstream.Accept()
+				if aerr != nil {
+					return
+				}
+				defer func() { _ = conn.Close() }()
+				reader := bufio.NewReader(conn)
+				_, _ = http.ReadRequest(reader)
+				resp := "HTTP/1.1 200 OK\r\n" +
+					tc.respHeaders +
+					"Content-Length: 0\r\n" +
+					"\r\n"
+				_, _ = conn.Write([]byte(resp))
+			})
+			t.Cleanup(wg.Wait)
+
+			proxy := NewProxyUnderTest(t, rawUpstream.Addr().String())
+			defer proxy.Close()
+
+			conn, err := net.DialTimeout("tcp", proxy.Addr(), 5*time.Second)
+			if err != nil {
+				t.Fatalf("dial proxy: %v", err)
+			}
+			defer func() { _ = conn.Close() }()
+
+			req, _ := http.NewRequest("GET", "http://example.com/e5", nil)
+			if err := req.WriteProxy(conn); err != nil {
+				t.Fatalf("write request: %v", err)
+			}
+
+			resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+			if err != nil {
+				t.Fatalf("read response: %v", err)
+			}
+			defer func() { _ = resp.Body.Close() }()
+
+			assertStatusCode(t, resp, http.StatusBadGateway)
+			if ps := resp.Header.Get("Proxy-Status"); !strings.Contains(ps, "http_protocol_error") {
+				t.Errorf("expected Proxy-Status to contain 'http_protocol_error', got %q", ps)
+			}
+			// The injected header MUST NOT reach the client.
+			if got := resp.Header.Get("Injected"); got != "" {
+				t.Errorf("client saw injected header %q; expected absent", got)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// E5b — RFC 9110 §5.5: CRLF injection in request header forwarded to upstream
+// ---------------------------------------------------------------------------
+//
+// Defence-in-depth: when a client emits a header line that injects a second
+// header via embedded CRLF, the upstream must NOT see the injected header.
+// Go's http.ReadRequest splits on CRLF during parse, so the inbound parser
+// will already separate them into two headers — the relevant assertion is
+// that whichever header is forwarded, no smuggled header reaches upstream
+// with a value containing CR or LF.
+
+func TestE5_RFC9110_RequestHeaderCRLFNotForwarded(t *testing.T) {
+	raw := "GET http://example.com/e5b HTTP/1.1\r\n" +
+		"Host: example.com\r\n" +
+		"X-Evil: foo\r\n X-Continued: tab-folded\r\n" +
+		"\r\n"
+	resp, reqs := proxyRawRoundTrip(t, raw)
+	defer func() { _ = resp.Body.Close() }()
+
+	// Either a clean 200 with the header normalised, or a 4xx rejection.
+	// The forbidden outcome is the upstream receiving a header value that
+	// contains bare CR or LF.
+	for _, r := range reqs {
+		for k, vs := range r.Header {
+			for _, v := range vs {
+				if strings.ContainsAny(v, "\r\n") {
+					t.Errorf("upstream header %q has CR/LF in value %q", k, v)
+				}
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// E6 — RFC 9112 §7.1.1: Chunk-extensions handled without misframing
+// ---------------------------------------------------------------------------
+//
+// Chunked encoding allows chunk-extensions after the chunk size. Go's
+// chunked reader tolerates them and drops them; the proxy MUST relay the
+// body intact regardless. Test: send a chunked POST with an extension on
+// the data chunk; verify the upstream receives the original body bytes.
+
+func TestE6_RFC9112_ChunkExtensionsForwardedSafely(t *testing.T) {
+	const wantBody = "hello"
+
+	upstream := NewMockUpstreamProxy(t, nil)
+	defer upstream.Close()
+
+	proxy := NewProxyUnderTest(t, upstream.Addr())
+	defer proxy.Close()
+
+	conn, err := net.DialTimeout("tcp", proxy.Addr(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	// Chunked POST with a chunk-extension on the data chunk.
+	raw := "POST http://example.com/e6 HTTP/1.1\r\n" +
+		"Host: example.com\r\n" +
+		"Transfer-Encoding: chunked\r\n" +
+		"\r\n" +
+		"5;ext=foo\r\nhello\r\n" +
+		"0\r\n" +
+		"\r\n"
+	if _, err := conn.Write([]byte(raw)); err != nil {
+		t.Fatalf("write raw request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	assertStatusCode(t, resp, http.StatusOK)
+
+	reqs := upstream.Requests()
+	if len(reqs) != 1 {
+		t.Fatalf("upstream received %d requests, want 1", len(reqs))
+	}
+	if got := string(reqs[0].BodyBytes); got != wantBody {
+		t.Errorf("upstream body: want %q, got %q", wantBody, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests for response header byte validation
+// ---------------------------------------------------------------------------
+
+func TestValidateResponseHeaderBytes_Unit(t *testing.T) {
+	tests := []struct {
+		name    string
+		hdr     http.Header
+		wantErr bool
+	}{
+		{name: "clean", hdr: http.Header{"X-Ok": {"value"}}},
+		{name: "tab_ok", hdr: http.Header{"X-Ok": {"a\tb"}}},
+		{name: "obs_text_high_ok", hdr: http.Header{"X-Ok": {"a\xc3\xa9"}}}, // UTF-8 é
+		{name: "empty_value_ok", hdr: http.Header{"X-Ok": {""}}},
+		{name: "bare_CR", hdr: http.Header{"X-Bad": {"a\rb"}}, wantErr: true},
+		{name: "bare_LF", hdr: http.Header{"X-Bad": {"a\nb"}}, wantErr: true},
+		{name: "NUL", hdr: http.Header{"X-Bad": {"a\x00b"}}, wantErr: true},
+		{name: "BEL", hdr: http.Header{"X-Bad": {"a\x07b"}}, wantErr: true},
+		{name: "DEL", hdr: http.Header{"X-Bad": {"a\x7fb"}}, wantErr: true},
+		{name: "bad_name_space", hdr: http.Header{"X Bad": {"v"}}, wantErr: true},
+		{name: "bad_name_paren", hdr: http.Header{"X(Bad)": {"v"}}, wantErr: true},
+		{name: "bad_name_colon_in_key", hdr: http.Header{"X:Bad": {"v"}}, wantErr: true},
+		{name: "bad_name_empty", hdr: http.Header{"": {"v"}}, wantErr: true},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := &http.Response{Header: tc.hdr}
+			pe := validateResponseHeaderBytes(resp)
+			if tc.wantErr && pe == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tc.wantErr && pe != nil {
+				t.Errorf("expected nil, got error: %s", pe.errorType)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// E7 — RFC 9112 §7.1.2: Trailer fields handled consistently
+// ---------------------------------------------------------------------------
+//
+// The proxy lists Trailer in its hop-by-hop strip set. When an upstream
+// chunked response includes trailers, the proxy must EITHER forward them
+// (declaring Trailer) OR strip them — but it must be consistent and must
+// not leave a Trailer header pointing at trailers the client will never
+// receive. Asserts that the response framing remains valid (chunked
+// terminator is reached, body is correctly delimited).
+
+func TestE7_RFC9112_ChunkedResponseWithTrailerConsistent(t *testing.T) {
+	rawUpstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer func() { _ = rawUpstream.Close() }()
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		conn, aerr := rawUpstream.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		reader := bufio.NewReader(conn)
+		_, _ = http.ReadRequest(reader)
+		// Chunked response carrying a Trailer header + actual trailer
+		// field after the zero chunk.
+		resp := "HTTP/1.1 200 OK\r\n" +
+			"Transfer-Encoding: chunked\r\n" +
+			"Trailer: X-Checksum\r\n" +
+			"\r\n" +
+			"5\r\nhello\r\n" +
+			"0\r\n" +
+			"X-Checksum: abc123\r\n" +
+			"\r\n"
+		_, _ = conn.Write([]byte(resp))
+	})
+	t.Cleanup(wg.Wait)
+
+	proxy := NewProxyUnderTest(t, rawUpstream.Addr().String())
+	defer proxy.Close()
+
+	conn, err := net.DialTimeout("tcp", proxy.Addr(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer func() { _ = conn.Close() }()
+
+	req, _ := http.NewRequest("GET", "http://example.com/e7", nil)
+	if err := req.WriteProxy(conn); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	// Read the full response, including body, so we can assert framing
+	// is intact (no truncation, no leftover trailer bytes on the wire).
+	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	assertStatusCode(t, resp, http.StatusOK)
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	if !bytes.Equal(body, []byte("hello")) {
+		t.Errorf("body: want %q, got %q", "hello", body)
+	}
+
+	// Consistency: if Trailer header advertises a name, either the trailer
+	// value must arrive (resp.Trailer populated) OR Trailer must be
+	// stripped from the response headers. The proxy must not advertise
+	// trailers it will never deliver.
+	advertised := resp.Header.Get("Trailer")
+	if advertised != "" {
+		// Trailer advertised → the named trailer must be present.
+		if v := resp.Trailer.Get(advertised); v == "" {
+			t.Errorf("Trailer %q advertised but absent from resp.Trailer (=%v)", advertised, resp.Trailer)
+		}
+	}
+}

--- a/harness_test.go
+++ b/harness_test.go
@@ -413,6 +413,58 @@ func proxyRawRoundTripWithUpstream(t *testing.T, rawReq string, respFunc func(*h
 	return resp, upstream.Requests()
 }
 
+// rawCannedUpstreamRoundTrip stands up a raw TCP "upstream" that reads one
+// request and writes cannedResp verbatim (bypassing http.Response.Write so
+// malformed/adversarial bytes survive on the wire), fronts it with a
+// ProxyUnderTest, sends a single absolute-form GET through the proxy, and
+// returns the parsed client response. The caller owns resp.Body.
+//
+// It exists because NewMockUpstreamProxy serialises responses via
+// resp.Write, which sanitises headers and therefore cannot emit the
+// malformed framing these RFC 9112 §6.1/§11.1 conformance tests require.
+func rawCannedUpstreamRoundTrip(t *testing.T, urlPath, cannedResp string) *http.Response {
+	t.Helper()
+
+	rawUpstream, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = rawUpstream.Close() })
+
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		conn, aerr := rawUpstream.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, _ = http.ReadRequest(bufio.NewReader(conn))
+		_, _ = conn.Write([]byte(cannedResp))
+	})
+	t.Cleanup(wg.Wait)
+
+	proxy := NewProxyUnderTest(t, rawUpstream.Addr().String())
+	t.Cleanup(proxy.Close)
+
+	conn, err := net.DialTimeout("tcp", proxy.Addr(), 5*time.Second)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+
+	req, _ := http.NewRequest("GET", "http://example.com"+urlPath, nil)
+	if err := req.WriteProxy(conn); err != nil {
+		t.Fatalf("write request: %v", err)
+	}
+
+	resp, err := http.ReadResponse(bufio.NewReader(conn), req)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
 // waitForDone waits for a done channel to be closed, failing the test if it
 // does not close within 5 seconds. This replaces the repeated
 // select { case <-done: case <-time.After(5*time.Second): t.Fatal(...) }

--- a/main.go
+++ b/main.go
@@ -300,6 +300,76 @@ func sanitizeHopByHop(req *http.Request) {
 	}
 }
 
+// validateResponseHeaderBytes scans every upstream-emitted header field name
+// and value for octets that RFC 9110 §5.5 / RFC 9112 §11.1 forbid: bare CR,
+// bare LF, NUL, and other ASCII control characters (octets 0x00-0x08,
+// 0x0A-0x1F, excluding HTAB 0x09). The presence of any such octet inside a
+// post-parse value indicates either a malformed upstream emitter or a
+// response-splitting attempt; either way the proxy MUST NOT relay it.
+// Returns a non-nil *proxyError to reject the response with 502.
+//
+// Field names are validated against the RFC 9110 §5.1 tchar production so
+// that header lines with control characters in the name are also rejected.
+//
+// Note: when an upstream emits a value containing a clean "\r\n" sequence
+// followed by another well-formed "Name: value" pair, Go's textproto parser
+// splits them into two distinct headers — this is indistinguishable from
+// an intentional dual-header response and cannot be detected here.
+func validateResponseHeaderBytes(resp *http.Response) *proxyError {
+	for name, values := range resp.Header {
+		if !isValidFieldName(name) {
+			return errMalformedResponseHeader
+		}
+		if slices.ContainsFunc(values, hasForbiddenFieldValueByte) {
+			return errMalformedResponseHeader
+		}
+	}
+	return nil
+}
+
+// isValidFieldName reports whether name contains only RFC 9110 §5.1 tchar
+// characters. Used to reject upstream response header names containing
+// control characters introduced via a response-splitting attempt.
+func isValidFieldName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9':
+			continue
+		}
+		switch c {
+		case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.',
+			'^', '_', '`', '|', '~':
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// hasForbiddenFieldValueByte reports whether v contains any octet forbidden
+// in an HTTP field-value per RFC 9110 §5.5: NUL, CR, LF, and other ASCII
+// control characters (0x00-0x08, 0x0A-0x1F). HTAB (0x09) is permitted.
+// obs-text (0x80-0xFF) is also permitted because senders MAY emit it and
+// recipients SHOULD pass it through.
+func hasForbiddenFieldValueByte(v string) bool {
+	for i := 0; i < len(v); i++ {
+		c := v[i]
+		if c == '\t' {
+			continue
+		}
+		if c < 0x20 || c == 0x7F {
+			return true
+		}
+	}
+	return false
+}
+
 // validateResponseContentLength checks the upstream response for invalid
 // Content-Length values per RFC 9112 §6.1. It returns a non-nil *proxyError
 // when the response must be rejected with 502.
@@ -340,6 +410,11 @@ func validateResponseContentLength(resp *http.Response) *proxyError {
 // detected by Go's ReadResponse or by validateResponseContentLength.
 var errContentLengthInvalid = errors.New("invalid Content-Length in upstream response")
 
+// errMalformedResponse is a sentinel error returned by readUpstreamResponse
+// when the upstream response contains a malformed header field name or
+// forbidden control octet in a header value (RFC 9110 §5.5 / RFC 9112 §11.1).
+var errMalformedResponse = errors.New("malformed upstream response header")
+
 // readUpstreamResponse reads and validates an upstream HTTP response. It
 // performs: ReadResponse, Content-Length error detection, content-length
 // validation, Transfer-Encoding / Content-Length conflict resolution, and
@@ -377,6 +452,15 @@ func readUpstreamResponse(upstreamReader *bufio.Reader, req *http.Request, pseud
 	if pe := validateResponseContentLength(resp); pe != nil {
 		_ = resp.Body.Close()
 		return nil, errContentLengthInvalid
+	}
+
+	// RFC 9110 §5.5 / RFC 9112 §11.1: reject responses whose header field
+	// names or values contain forbidden control octets (response-splitting
+	// defence-in-depth). Go's textproto parser already rejects most such
+	// content, but a bare CR mid-value or a NUL byte can survive parsing.
+	if pe := validateResponseHeaderBytes(resp); pe != nil {
+		_ = resp.Body.Close()
+		return nil, errMalformedResponse
 	}
 
 	// RFC 9112 §6.1: if both Transfer-Encoding and Content-Length
@@ -512,6 +596,12 @@ var (
 		statusCode: http.StatusBadGateway,
 		errorType:  errorTypeHTTPProtocolError,
 		message:    "The upstream proxy sent a response with an invalid Content-Length header.",
+		action:     "This may indicate a misconfigured upstream proxy or an attempt at response splitting. Contact the upstream proxy administrator.",
+	}
+	errMalformedResponseHeader = &proxyError{
+		statusCode: http.StatusBadGateway,
+		errorType:  errorTypeHTTPProtocolError,
+		message:    "The upstream proxy sent a response containing a header field with a malformed name or a forbidden control character in its value.",
 		action:     "This may indicate a misconfigured upstream proxy or an attempt at response splitting. Contact the upstream proxy administrator.",
 	}
 	errForbiddenPort = &proxyError{
@@ -672,8 +762,9 @@ func tokenErrorToProxyError(err error) *proxyError {
 }
 
 // handleUpstreamResponseError handles errors from readUpstreamResponse.
-// For invalid Content-Length it sends a 502 error to the client; for all
-// other errors it falls back to raw-relaying the upstream bytes.
+// For invalid Content-Length or malformed response headers it sends a 502
+// error to the client; for all other errors it falls back to raw-relaying
+// the upstream bytes.
 func handleUpstreamResponseError(conn, proxyConn net.Conn, err error, clientAddr string) {
 	if errors.Is(err, errContentLengthInvalid) {
 		slog.Error("invalid Content-Length in upstream response",
@@ -681,6 +772,14 @@ func handleUpstreamResponseError(conn, proxyConn net.Conn, err error, clientAddr
 			"client_addr", clientAddr,
 			"upstream_addr", proxyConn.RemoteAddr())
 		writeHTTPError(conn, errInvalidContentLength)
+		return
+	}
+	if errors.Is(err, errMalformedResponse) {
+		slog.Error("malformed upstream response header",
+			"error", err, "error_type", errMalformedResponseHeader.errorType,
+			"client_addr", clientAddr,
+			"upstream_addr", proxyConn.RemoteAddr())
+		writeHTTPError(conn, errMalformedResponseHeader)
 		return
 	}
 	slog.Warn("unparseable upstream response",

--- a/main.go
+++ b/main.go
@@ -311,6 +311,12 @@ func sanitizeHopByHop(req *http.Request) {
 // Field names are validated against the RFC 9110 §5.1 tchar production so
 // that header lines with control characters in the name are also rejected.
 //
+// These checks duplicate golang.org/x/net/http/httpguts.ValidHeaderField*,
+// but that package transitively imports golang.org/x/net/idna →
+// golang.org/x/text, which is otherwise not a dependency. The ASCII byte
+// scans below are trivial, allocation-free, and keep the dependency
+// surface of this security-sensitive proxy minimal.
+//
 // Note: when an upstream emits a value containing a clean "\r\n" sequence
 // followed by another well-formed "Name: value" pair, Go's textproto parser
 // splits them into two distinct headers — this is indistinguishable from


### PR DESCRIPTION
Address the message-framing batch from issue #217's conformance gap
catalogue (RFC 9112 §6.1, §7.1.1, §7.1.2, §11.1; RFC 9110 §5.5).

main.go
  - validateResponseHeaderBytes: post-parse scan of every upstream
    response header. Rejects field names that contain non-tchar
    characters and field values that contain bare CR, bare LF, NUL,
    or other ASCII control octets (0x00-0x08, 0x0A-0x1F, 0x7F).
    HTAB and obs-text (0x80-0xFF) remain permitted.
  - isValidFieldName / hasForbiddenFieldValueByte: helpers
    implementing the RFC 9110 §5.1 tchar and §5.5 field-vchar
    productions respectively.
  - errMalformedResponse sentinel + errMalformedResponseHeader
    proxyError. readUpstreamResponse rejects offending responses
    with 502 http_protocol_error; handleUpstreamResponseError maps
    the sentinel to the client-facing error.

framing_conformance_test.go (new)
  - E3 (non-chunked request Transfer-Encoding): "gzip" and
    "chunked, gzip" must not be forwarded.
  - E4 (request-side Content-Length anomalies): negative, +prefix,
    hex, duplicate-differing, non-numeric all rejected.
  - E5 (response header control-octet defence): bare CR, NUL, BEL
    in upstream header value -> 502 http_protocol_error.
  - E5b (request CR/LF not forwarded): defensive coverage of
    inbound header value sanitisation.
  - E6 (chunk-extensions): chunked POST with "5; ext=foo" forwards
    intact body bytes.
  - E7 (chunked trailer consistency): Trailer advertisement only
    survives in the response when the trailer is actually
    delivered.
  - Unit coverage of validateResponseHeaderBytes (clean ASCII,
    HTAB, UTF-8 obs-text accepted; control octets and malformed
    names rejected).

docs/http-proxy-standards-requirements.md
  - New §E4-E8 entries with normative quotes, levels, and explicit
    traceability to the new tests.
  - Tier 1 matrix updated with E4-E8.

Limitation documented: a clean "Name: value\r\nInjected: 1\r\n"
payload parses to two well-formed headers and is indistinguishable
from an intentional dual-header response. Detection there would
require pre-parse byte inspection that breaks legitimate traffic;
the defence here targets the variants that survive textproto
parsing.

Refs #217.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>