### PR TITLE
fix: IPv6 no-proxy bracket matching + native fuzz suite

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -1,0 +1,52 @@
+name: Fuzz
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  fuzz:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - FuzzNoProxyMatch
+          - FuzzUpstreamResponseFraming
+          - FuzzConnectPortChain
+          - FuzzSameHost
+          - FuzzIPAllowlistChain
+          - FuzzContentLengthValues
+          - FuzzHeaderByteValidators
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: .go-version
+
+      - name: Fuzz
+        env:
+          CGO_ENABLED: "0"
+          TARGET: ${{ matrix.target }}
+        # -run '^$' skips unit tests; the anchored -fuzz regex resolves to
+        # exactly one target. A discovered crash exits non-zero (failing the
+        # job) and writes a reproducer to testdata/fuzz/. '.' not './...' —
+        # go test -fuzz rejects multi-package runs.
+        run: go test -run '^$' -fuzz "^${TARGET}$" -fuzztime=300s .
+
+      - name: Upload crashers
+        if: failure()
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: fuzz-crash-${{ matrix.target }}
+          path: testdata/fuzz/
+          if-no-files-found: ignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,25 @@ Go 1.25. Use modern Go idioms (wg.Go, SplitSeq, t.Context).
 
     golangci-lint run
 
+## Fuzzing
+
+See `CONTRIBUTING.md` § Fuzzing for the full human-oriented guide.
+
+Key details for AI context:
+
+- Native `go test -fuzz` targets; seed corpora in `f.Add`; crash reproducers
+  committed under `testdata/fuzz/<Target>/` and replayed free by `go test ./...`
+- **No new dependency** for an oracle. `golang.org/x/net/http/httpproxy` and
+  `httpguts` transitively pull `golang.org/x/text` — never import them; write a
+  clean-room stdlib reference. Confirm with `go mod tidy` (no diff)
+- Differential oracle must be sound (gate on parseability; assert only the
+  security direction; never mirror the production impl). Else ship crash-only
+- Targets hermetic, deterministic, `CGO_ENABLED=0`, entropy via
+  `[]byte`/`string`/scalars (OSS-Fuzz portable)
+- Real bug → `fix:` + commit reproducer as regression seed. Unsound oracle →
+  tighten predicate and delete the noise reproducer (never commit it)
+- Add every new `Fuzz*` name to the matrix in `.github/workflows/fuzz.yml`
+
 ## Release Process
 
 See `CONTRIBUTING.md` § Releasing for the full human-oriented guide.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,60 @@ The tests are gated by `//go:build darwin` and the `INTEGRATION` environment
 variable — they skip automatically on Linux and when `INTEGRATION` is unset.
 They also skip if MIT krb5 is not installed.
 
+### Fuzzing
+
+The proxy has native Go fuzz targets (`go test -fuzz`) covering the inputs an
+unprivileged client or a malicious origin controls. Seed corpora live in
+`f.Add` calls; discovered crash reproducers are committed under
+`testdata/fuzz/<Target>/` and replayed for free by the ordinary
+`go test ./...` run (so a fixed bug stays fixed). The `Fuzz` workflow runs
+time-boxed discovery nightly.
+
+Run one target locally:
+
+```bash
+go test -run '^$' -fuzz '^FuzzNoProxyMatch$' -fuzztime=60s .
+```
+
+Replay only the committed corpus (no discovery), as CI does:
+
+```bash
+go test -count=1 ./...
+```
+
+#### When to add a target
+
+Add a target when you introduce or change code that parses or makes a
+policy/framing decision on attacker-influenced input: request authority,
+headers, client address, or an upstream response. Do **not** fuzz the standard
+library directly (the Go team already does) — fuzz *our* logic, optionally
+*through* a stdlib parser used as part of the chain.
+
+#### Rules (these are load-bearing — they were each a trap)
+
+1. **No new dependency.** This is a security-sensitive proxy with a deliberately
+   small dependency set. A differential oracle must use only the standard
+   library or a package already in `go.mod`. In particular
+   `golang.org/x/net/http/httpproxy` and `golang.org/x/net/http/httpguts`
+   transitively pull `golang.org/x/text` — do **not** import them. Write a
+   clean-room reference instead. Verify with `go mod tidy` producing no diff.
+2. **Sound oracle, or crash-only.** A differential assertion must not flag
+   intended behaviour. Gate on parseability; assert only the
+   security-meaningful direction (e.g. "accepted ⇒ literally permitted", not a
+   re-derivation that re-implements the function); never bake the production
+   implementation's semantics into the reference. If you cannot construct a
+   sound oracle, ship the target as no-panic / invariant-only.
+3. **OSS-Fuzz portable.** Entropy only via `[]byte`/`string`/scalars in
+   `f.Fuzz`; targets must be hermetic and deterministic (no network, files,
+   clock, randomness, global state) and build with `CGO_ENABLED=0`. This keeps
+   ClusterFuzzLite / OSS-Fuzz a future drop-in with no target rewrite.
+4. **Reproducer hygiene.** If a target fails: a *real* bug → fix the production
+   code and commit the reproducer (it becomes a regression seed) with a `fix:`
+   commit; an *unsound oracle* → tighten the predicate and **delete** the noise
+   reproducer (do not commit it).
+5. **Register the target.** Add every new `Fuzz*` function name to the matrix
+   in `.github/workflows/fuzz.yml` so nightly discovery covers it.
+
 ## Formatting
 
 All code must be formatted before committing. CI will reject unformatted code.

--- a/config.go
+++ b/config.go
@@ -121,6 +121,14 @@ func ipAllowed(ip net.IP, allowList []*net.IPNet) bool {
 	if len(allowList) == 0 {
 		return true
 	}
+	// RFC 4291: an IPv4-mapped IPv6 address denotes the same host as the bare
+	// IPv4 address. Canonicalise to the 4-byte form so allowlist identity is
+	// consistent regardless of which form the client connected with. (Behaviour
+	// is unchanged — net.IPNet.Contains already aligns families via To4 — but
+	// making it explicit documents the contract and pins it under fuzzing.)
+	if v4 := ip.To4(); v4 != nil {
+		ip = v4
+	}
 	for _, n := range allowList {
 		if n.Contains(ip) {
 			return true

--- a/config_fuzz_test.go
+++ b/config_fuzz_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"net"
+	"net/netip"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -47,6 +49,90 @@ func FuzzConnectPortChain(f *testing.F) {
 				t.Fatalf("port smuggled past gate: authority=%q port=%q allowed=%v accepted=true but port not listed",
 					authority, port, allowed)
 			}
+		}
+	})
+}
+
+// ipAllowRef is an independent netip-based re-derivation of the allowlist
+// membership decision under the ratified Option A policy (RFC 4291): the
+// client address is Unmap-ed so an IPv4-in-IPv6 form is the same identity as
+// the bare IPv4 address.
+//
+// To keep the oracle sound it is scoped to a grammar where net and netip agree
+// unambiguously: allowlist tokens must be pure (non IPv4-in-IPv6) IPs or CIDRs.
+// A mapped form on the *client* side is fully exercised — that is the
+// security-critical attacker-controlled input. applicable=false means the
+// input is outside the sound differential grammar and no claim is made.
+func ipAllowRef(clientHost, allowCSV string) (decision bool, applicable bool) {
+	ca, err := netip.ParseAddr(clientHost)
+	if err != nil {
+		return false, false
+	}
+	ca = ca.Unmap()
+
+	var prefixes []netip.Prefix
+	for _, tok := range splitCSV(allowCSV) {
+		if strings.Contains(tok, "/") {
+			p, e := netip.ParsePrefix(tok)
+			if e != nil || p.Addr().Is4In6() {
+				return false, false
+			}
+			prefixes = append(prefixes, p.Masked())
+		} else {
+			a, e := netip.ParseAddr(tok)
+			if e != nil || a.Is4In6() {
+				return false, false
+			}
+			prefixes = append(prefixes, netip.PrefixFrom(a, a.BitLen()))
+		}
+	}
+	if len(prefixes) == 0 {
+		return false, false
+	}
+	for _, p := range prefixes {
+		if p.Contains(ca) {
+			return true, true
+		}
+	}
+	return false, true
+}
+
+// FuzzIPAllowlistChain mirrors the production client-IP gate
+// (extractHost(RemoteAddr) -> net.ParseIP -> ipAllowed over parseAllowList)
+// and asserts the membership decision matches an independent netip
+// re-derivation under Option A. A divergence is a real allowlist
+// bypass/escape (an attacker IP wrongly admitted, or a permitted client
+// wrongly denied).
+func FuzzIPAllowlistChain(f *testing.F) {
+	f.Add("1.2.3.4:5", "1.2.3.0/24")
+	f.Add("::ffff:127.0.0.1", "127.0.0.0/8")
+	f.Add("[::ffff:1.2.3.4]:80", "1.2.3.4/32")
+	f.Add("10.0.0.1", "10.0.0.0/8")
+	f.Add("not-an-ip", "0.0.0.0/0")
+	f.Add("[fe80::1%eth0]:80", "fe80::/10")
+	f.Add("", "1.2.3.4")
+	f.Add("192.168.1.5:9", "192.168.1.5")
+	f.Add("2001:db8::1", "2001:db8::/32")
+
+	f.Fuzz(func(t *testing.T, rawRemote, allowCSV string) {
+		clientHost := extractHost(rawRemote)
+
+		// (1) Production chain never panics.
+		nets, perr := parseAllowList(allowCSV)
+		prodIP := net.ParseIP(clientHost)
+		prodDecision := ipAllowed(prodIP, nets)
+
+		// (2) Sound differential, gated on both sides fully parsing.
+		if perr != nil || prodIP == nil {
+			return
+		}
+		refDecision, applicable := ipAllowRef(clientHost, allowCSV)
+		if !applicable {
+			return
+		}
+		if prodDecision != refDecision {
+			t.Fatalf("allowlist decision divergence: clientHost=%q allow=%q prod=%v ref=%v",
+				clientHost, allowCSV, prodDecision, refDecision)
 		}
 	})
 }

--- a/config_fuzz_test.go
+++ b/config_fuzz_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"net"
+	"slices"
+	"testing"
+)
+
+// FuzzConnectPortChain mirrors the production CONNECT port-gate chain
+// (prepareForwardRequest, forward.go:40-49): the client-controlled authority
+// is split by net.SplitHostPort, defaulting to "443" on error, and the port is
+// checked against the configured allow set.
+//
+// The oracle is the security-direction implication only — connectPortAllowed
+// does a pure byte-wise string compare (config.go:135), so a numeric/uint16
+// equivalence oracle would be unsound (it would false-positive on "0443",
+// "+443", etc., which the function correctly rejects). The sound, security-
+// relevant property is: an accepted port under a non-empty, non-wildcard allow
+// set must be byte-identical to a configured entry. No input may smuggle a
+// port past the gate that is not literally listed.
+func FuzzConnectPortChain(f *testing.F) {
+	f.Add("host:443", "443")
+	f.Add("host", "443")
+	f.Add("host:0443", "443")
+	f.Add("host:443\x00", "443")
+	f.Add("[::1]:8443", "8443, *")
+	f.Add("h:443 ", "443")
+	f.Add("h:+443", "443")
+	f.Add("h:0x1bb", "443")
+	f.Add("[::1", "443")
+	f.Add("h:99999", "443")
+	f.Add("h:443:evil", "443")
+	f.Add("", "")
+
+	f.Fuzz(func(t *testing.T, authority, allowedCSV string) {
+		allowed := splitCSV(allowedCSV)
+
+		_, port, err := net.SplitHostPort(authority)
+		if err != nil {
+			port = "443"
+		}
+
+		accepted := connectPortAllowed(port, allowed)
+
+		if accepted && len(allowed) > 0 && !slices.Contains(allowed, connectPortWildcard) {
+			if !slices.Contains(allowed, port) {
+				t.Fatalf("port smuggled past gate: authority=%q port=%q allowed=%v accepted=true but port not listed",
+					authority, port, allowed)
+			}
+		}
+	})
+}

--- a/direct_fuzz_test.go
+++ b/direct_fuzz_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"net"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// sameHostRef is an independent canonicalisation used only to bound sameHost's
+// true-decisions. It deliberately differs from production (independent bracket
+// stripping; explicit netip normalisation of IP literals) so a collision bug
+// in production's canon — two genuinely different hosts treated as the same,
+// the response/request-smuggling vector at direct.go:104-110 — is caught.
+func sameHostRef(h, defaultPort string) string {
+	h = strings.ToLower(strings.TrimSpace(h))
+	host, port, err := net.SplitHostPort(h)
+	if err != nil {
+		host = h
+		port = defaultPort
+		host = strings.TrimPrefix(host, "[")
+		host = strings.TrimSuffix(host, "]")
+	}
+	if a, e := netip.ParseAddr(host); e == nil {
+		host = a.String()
+	}
+	return host + "|" + port
+}
+
+// FuzzSameHost guards the keep-alive connection binding in handleDirectHTTP:
+// sameHost falsely reporting two different hosts as equal lets a smuggled
+// pipelined request ride a direct connection bound to a different,
+// unauthorised host (direct.go:104-110).
+//
+// Assertions:
+//   - never panics;
+//   - reflexivity: sameHost(a,a,d) is always true;
+//   - symmetry: sameHost(a,b,d) == sameHost(b,a,d);
+//   - one-directional soundness: sameHost(a,b,d)==true implies an independent
+//     canonicalisation also considers them equal. The converse is NOT asserted
+//     (production being stricter than the reference is safe).
+func FuzzSameHost(f *testing.F) {
+	f.Add("Example.com:80", "example.com", "80")
+	f.Add("[::1]", "[0:0:0:0:0:0:0:1]:80", "80")
+	f.Add("[::1]:80", "[::1]:80", "80")
+	f.Add("host", "host:80", "80")
+	f.Add(" host ", "host", "80")
+	f.Add("[::ffff:1.2.3.4]", "1.2.3.4", "443")
+	f.Add("h:80", "h:0080", "80")
+	f.Add("[bad", "[bad", "80")
+	f.Add("a:b:c", "a:b:c", "443")
+
+	f.Fuzz(func(t *testing.T, a, b, defaultPort string) {
+		if !sameHost(a, a, defaultPort) {
+			t.Fatalf("reflexivity violated: sameHost(%q,%q,%q)=false", a, a, defaultPort)
+		}
+		ab := sameHost(a, b, defaultPort)
+		if ab != sameHost(b, a, defaultPort) {
+			t.Fatalf("symmetry violated: a=%q b=%q d=%q", a, b, defaultPort)
+		}
+		if ab && sameHostRef(a, defaultPort) != sameHostRef(b, defaultPort) {
+			t.Fatalf("sameHost equated different hosts (smuggling vector): a=%q b=%q d=%q ref(a)=%q ref(b)=%q",
+				a, b, defaultPort, sameHostRef(a, defaultPort), sameHostRef(b, defaultPort))
+		}
+	})
+}

--- a/noproxy.go
+++ b/noproxy.go
@@ -77,6 +77,11 @@ func (m *NoProxyMatcher) Match(host string) (matched bool, pattern string) {
 	// Strip port if present.
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
+	} else if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		// Bare bracketed IPv6 literal with no port (e.g. "[::1]"): strip the
+		// brackets so it parses as an IP for IP/CIDR rule matching, mirroring
+		// sameHost in direct.go.
+		host = host[1 : len(host)-1]
 	}
 	host = strings.ToLower(host)
 

--- a/noproxy_fuzz_test.go
+++ b/noproxy_fuzz_test.go
@@ -1,0 +1,177 @@
+package main
+
+import (
+	"net"
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// scopeNoProxyForDifferential filters a raw comma-separated no-proxy pattern
+// list down to only the pattern forms whose match semantics are simple and
+// unambiguous enough to re-derive independently from the documented NO_PROXY
+// contract:
+//
+//   - leading-dot domain suffix (".corp.com")
+//   - bare IP literal ("10.0.0.5", "::1")
+//   - CIDR ("10.0.0.0/8", "fd00::/8")
+//
+// Excluded (still exercised by the no-panic check, never the differential):
+//   - bare hostnames ("corp.com") — the de-facto NO_PROXY rule treats these as
+//     suffix-capable; this matcher treats them as exact-only. By design.
+//   - "*" and "*.corp.com" wildcards — not part of the portable contract.
+//
+// Returns the filtered list and whether any usable token survived.
+func scopeNoProxyForDifferential(raw string) (string, bool) {
+	var kept []string
+	for tok := range strings.SplitSeq(raw, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		switch {
+		case strings.HasPrefix(tok, ".") && len(tok) > 1:
+			kept = append(kept, tok)
+		case isParsablePrefix(tok):
+			kept = append(kept, tok)
+		case isParsableAddr(tok):
+			kept = append(kept, tok)
+		}
+	}
+	return strings.Join(kept, ","), len(kept) > 0
+}
+
+func isParsableAddr(s string) bool {
+	_, err := netip.ParseAddr(s)
+	return err == nil
+}
+
+func isParsablePrefix(s string) bool {
+	_, err := netip.ParsePrefix(s)
+	return err == nil
+}
+
+// canonicalHost mirrors the documented host-extraction contract of
+// NoProxyMatcher.Match ("host with or without a port", IPv6 brackets stripped,
+// case-insensitive). The differential deliberately shares this extraction step
+// with production: host extraction is NOT what is being differentially tested
+// (the one extraction bug — bracketed IPv6 without a port — is already fixed
+// and pinned by a regression seed). What IS independently re-derived is the
+// rule classification + matching logic in referenceNoProxyBypass.
+func canonicalHost(raw string) string {
+	h := raw
+	if x, _, err := net.SplitHostPort(h); err == nil {
+		h = x
+	} else if strings.HasPrefix(h, "[") && strings.HasSuffix(h, "]") {
+		h = h[1 : len(h)-1]
+	}
+	return strings.ToLower(h)
+}
+
+// differentiableHost reports whether h (already canonicalised) is a well-formed
+// IP literal or a clean DNS-charset name, so that the scoped rule grammar has
+// unambiguous semantics. Pathological non-authorities are not asserted on.
+func differentiableHost(h string) bool {
+	if h == "" {
+		return false
+	}
+	if _, err := netip.ParseAddr(h); err == nil {
+		return true
+	}
+	for i := 0; i < len(h); i++ {
+		c := h[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '.', c == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// referenceNoProxyBypass is an independent, clean-room implementation of the
+// NO_PROXY bypass decision for the scoped grammar only, given an
+// already-canonical host. It does NOT reuse production's rule structs or
+// classify chain: a divergence indicates a bug in noproxy.go's classification
+// or matching, not a shared assumption.
+//
+// golang.org/x/net/http/httpproxy is deliberately NOT used as the oracle: it
+// transitively imports golang.org/x/net/idna -> golang.org/x/text, which would
+// add a new dependency to a security-sensitive proxy that otherwise has none.
+func referenceNoProxyBypass(scoped, host string) bool {
+	hostIP, _ := netip.ParseAddr(host)
+	for tok := range strings.SplitSeq(scoped, ",") {
+		tok = strings.TrimSpace(tok)
+		if tok == "" {
+			continue
+		}
+		if strings.HasPrefix(tok, ".") {
+			suffix := strings.ToLower(tok)
+			if host == suffix[1:] || strings.HasSuffix(host, suffix) {
+				return true
+			}
+			continue
+		}
+		if pfx, err := netip.ParsePrefix(tok); err == nil {
+			if hostIP.IsValid() && pfx.Contains(hostIP) {
+				return true
+			}
+			continue
+		}
+		if a, err := netip.ParseAddr(tok); err == nil {
+			if hostIP.IsValid() && hostIP == a {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// FuzzNoProxyMatch is the highest-value fuzz target: a NoProxyMatcher.Match
+// that returns true when it should return false causes a request to bypass
+// the authenticated upstream proxy entirely (direct dial, no SPNEGO).
+//
+// Assertions:
+//  1. Match never panics for ANY (patterns, host) input.
+//  2. For the differentially-sound grammar and a well-formed host, the bypass
+//     decision must agree with an independent re-derivation of the contract.
+func FuzzNoProxyMatch(f *testing.F) {
+	f.Add(".corp.com", "foo.corp.com")
+	f.Add(".corp.com", "corp.com")
+	f.Add("10.0.0.0/8", "10.1.2.3")
+	f.Add("192.168.1.5", "192.168.1.5:443")
+	f.Add("*", "anything")
+	f.Add("*.corp.com", "a.corp.com")
+	f.Add("", "x")
+	f.Add(".com", "sub..com")
+	f.Add("[::1", "[::1")
+	f.Add("\x00", "\x00")
+	f.Add(".x", "A.X")
+	f.Add("1.2.3.0/24", "1.2.3.255")
+	f.Add("corp.com.", "corp.com")
+	f.Add("fd00::/8", "[fd00::1]:443")
+
+	f.Fuzz(func(t *testing.T, rawPatterns, rawHost string) {
+		// (1) Unconditional no-panic check on the full, unrestricted grammar.
+		_, _ = NewNoProxyMatcher(rawPatterns).Match(rawHost)
+
+		// (2) Sound differential, restricted to the congruent grammar and a
+		// well-formed host.
+		scoped, ok := scopeNoProxyForDifferential(rawPatterns)
+		if !ok {
+			return
+		}
+		host := canonicalHost(rawHost)
+		if !differentiableHost(host) {
+			return
+		}
+
+		ourBypass, _ := NewNoProxyMatcher(scoped).Match(rawHost)
+		refBypass := referenceNoProxyBypass(scoped, host)
+
+		if ourBypass != refBypass {
+			t.Fatalf("noproxy bypass divergence: patterns=%q rawHost=%q host=%q ourBypass=%v refBypass=%v",
+				scoped, rawHost, host, ourBypass, refBypass)
+		}
+	})
+}

--- a/response_fuzz_test.go
+++ b/response_fuzz_test.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"net/http"
 	"slices"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -70,6 +72,129 @@ func FuzzUpstreamResponseFraming(f *testing.F) {
 			t.Fatalf("framing divergence after round-trip (smuggling):\n"+
 				"  ContentLength %d -> %d\n  TransferEncoding %v -> %v\n  Close %v -> %v\n  input=%q",
 				cl1, cl2, te1, te2, close1, close2, data)
+		}
+	})
+}
+
+// FuzzContentLengthValues exercises validateResponseContentLength directly on
+// adversarial multi-value / comma-list Content-Length header sets. It is a
+// crash + tautology guard (the predicate re-derives the function's contract,
+// so it is intentionally not a differential): never panic, and acceptance
+// implies every non-empty comma part is a valid base-10 uint64 and all equal.
+func FuzzContentLengthValues(f *testing.F) {
+	f.Add("5")
+	f.Add("5, 5")
+	f.Add("5,6")
+	f.Add("+5")
+	f.Add("0x5")
+	f.Add("042")
+	f.Add(" 5 ")
+	f.Add("5,,5")
+	f.Add("")
+	f.Add("18446744073709551616")
+	f.Add("5\n5")
+	f.Add("5\n6")
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		// '\n'-separated header values; each value may itself be a comma list.
+		values := strings.Split(raw, "\n")
+		resp := &http.Response{Header: http.Header{"Content-Length": values}}
+
+		accepted := validateResponseContentLength(resp) == nil
+		if !accepted {
+			return
+		}
+
+		var first uint64
+		var seen bool
+		for _, v := range values {
+			for part := range strings.SplitSeq(v, ",") {
+				part = strings.TrimSpace(part)
+				if part == "" {
+					continue
+				}
+				n, err := strconv.ParseUint(part, 10, 64)
+				if err != nil {
+					t.Fatalf("accepted but part %q is not a base-10 uint64: raw=%q", part, raw)
+				}
+				if !seen {
+					first, seen = n, true
+				} else if n != first {
+					t.Fatalf("accepted but parts disagree (%d != %d): raw=%q", n, first, raw)
+				}
+			}
+		}
+	})
+}
+
+// isTcharByte is an independent definition of the RFC 9110 §5.6.2 tchar
+// production, written differently from isValidFieldName so it is a genuine
+// oracle rather than a copy.
+func isTcharByte(c byte) bool {
+	if c >= '0' && c <= '9' {
+		return true
+	}
+	if c >= 'A' && c <= 'Z' {
+		return true
+	}
+	if c >= 'a' && c <= 'z' {
+		return true
+	}
+	return strings.IndexByte("!#$%&'*+-.^_`|~", c) >= 0
+}
+
+// FuzzHeaderByteValidators is a self-referential property target (no external
+// oracle — httpguts would add golang.org/x/text). It pins the two leaf
+// response-splitting validators to independent byte-class definitions and
+// checks that validateResponseHeaderBytes' boolean verdict is consistent with
+// them. Only the boolean is asserted (validateResponseHeaderBytes ranges a map
+// and the *blamed* header is non-deterministic; the nil/non-nil result is not).
+func FuzzHeaderByteValidators(f *testing.F) {
+	f.Add("Content-Type", "text/html")
+	f.Add("X\x01", "v")
+	f.Add("Set-Cookie", "a\rb")
+	f.Add("Set-Cookie", "a\x7fb")
+	f.Add("Set-Cookie", "a\tb")
+	f.Add("Set-Cookie", "\x80\xff")
+	f.Add("", "v")
+	f.Add("ok", "")
+	f.Add("a b", "v")
+
+	f.Fuzz(func(t *testing.T, name, value string) {
+		gotName := isValidFieldName(name)
+		wantName := name != ""
+		if wantName {
+			for i := 0; i < len(name); i++ {
+				if !isTcharByte(name[i]) {
+					wantName = false
+					break
+				}
+			}
+		}
+		if gotName != wantName {
+			t.Fatalf("isValidFieldName(%q)=%v, independent oracle=%v", name, gotName, wantName)
+		}
+
+		gotVal := hasForbiddenFieldValueByte(value)
+		wantVal := false
+		for i := 0; i < len(value); i++ {
+			b := value[i]
+			if (b < 0x20 && b != '\t') || b == 0x7f {
+				wantVal = true
+				break
+			}
+		}
+		if gotVal != wantVal {
+			t.Fatalf("hasForbiddenFieldValueByte(%q)=%v, independent oracle=%v", value, gotVal, wantVal)
+		}
+
+		// Boolean consistency of the aggregate validator for a single header.
+		resp := &http.Response{Header: http.Header{name: []string{value}}}
+		gotAgg := validateResponseHeaderBytes(resp) != nil
+		wantAgg := !gotName || gotVal
+		if gotAgg != wantAgg {
+			t.Fatalf("validateResponseHeaderBytes inconsistent: name=%q value=%q agg=%v want=%v",
+				name, value, gotAgg, wantAgg)
 		}
 	})
 }

--- a/response_fuzz_test.go
+++ b/response_fuzz_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"net/http"
+	"slices"
+	"testing"
+)
+
+// FuzzUpstreamResponseFraming exercises the request-smuggling surface: if this
+// proxy's response validators accept an upstream response, then serialising
+// what we would forward and re-parsing it MUST yield identical body framing
+// (Content-Length / Transfer-Encoding / connection-close). A divergence means
+// the proxy and the downstream client would disagree on message length — a
+// response-smuggling desync.
+func FuzzUpstreamResponseFraming(f *testing.F) {
+	f.Add([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello"))
+	f.Add([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5, 5\r\n\r\nhello"))
+	f.Add([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5,6\r\n\r\nhello"))
+	f.Add([]byte("HTTP/1.1 200 OK\r\nContent-Length: +5\r\n\r\nhello"))
+	f.Add([]byte("HTTP/1.1 200 OK\r\nContent-Length: 0x5\r\n\r\nhello"))
+	f.Add([]byte("HTTP/1.1 200 OK\r\nContent-Length: 5\r\nContent-Length: 5\r\n\r\nhello"))
+	f.Add([]byte("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\nContent-Length: 5\r\n\r\n0\r\n\r\n"))
+	f.Add([]byte("HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n"))
+	f.Add([]byte("HTTP/1.1 204 No Content\r\n\r\n"))
+	f.Add([]byte("HTTP/1.1 200 OK\r\nX-H: a\rb\r\n\r\n"))
+	f.Add([]byte("HTTP/1.1 200 OK\r\nX-H: a\x00b\r\n\r\n"))
+	f.Add([]byte("HTTP/1.1 200 OK\r\nX\x01Y: v\r\n\r\n"))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		req := &http.Request{Method: "GET"}
+
+		resp1, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(data)), req)
+		if err != nil {
+			return
+		}
+
+		// Only the responses this proxy would actually forward are subject to
+		// the framing-stability claim.
+		if validateResponseContentLength(resp1) != nil || validateResponseHeaderBytes(resp1) != nil {
+			_ = resp1.Body.Close()
+			return
+		}
+
+		// Capture framing before resp.Write consumes the body.
+		cl1 := resp1.ContentLength
+		te1 := slices.Clone(resp1.TransferEncoding)
+		close1 := resp1.Close
+
+		var buf bytes.Buffer
+		werr := resp1.Write(&buf)
+		_ = resp1.Body.Close()
+		if werr != nil {
+			// Could not even serialise an accepted response: not a framing
+			// claim — skip rather than emit a false positive.
+			return
+		}
+
+		resp2, err := http.ReadResponse(bufio.NewReader(bytes.NewReader(buf.Bytes())), req)
+		if err != nil {
+			t.Fatalf("accepted response failed to re-parse (smuggling desync): %v\nserialised=%q", err, buf.Bytes())
+		}
+		cl2 := resp2.ContentLength
+		te2 := slices.Clone(resp2.TransferEncoding)
+		close2 := resp2.Close
+		_ = resp2.Body.Close()
+
+		if cl1 != cl2 || close1 != close2 || !slices.Equal(te1, te2) {
+			t.Fatalf("framing divergence after round-trip (smuggling):\n"+
+				"  ContentLength %d -> %d\n  TransferEncoding %v -> %v\n  Close %v -> %v\n  input=%q",
+				cl1, cl2, te1, te2, close1, close2, data)
+		}
+	})
+}

--- a/testdata/fuzz/FuzzNoProxyMatch/4e3d56e8f8cb2156
+++ b/testdata/fuzz/FuzzNoProxyMatch/4e3d56e8f8cb2156
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("::0")
+string("[::]")


### PR DESCRIPTION
## Summary

- Adds 7 native `go test -fuzz` targets covering the attacker-influenced
  surface: NO_PROXY matching, CONNECT port gate, client-IP allowlist,
  keep-alive host binding, upstream response framing, Content-Length, and
  header-byte validators.
- **Found and fixed 1 real bug**: `NoProxyMatcher.Match` only stripped IPv6
  brackets when a port was present, so a bare `[::1]` silently never matched
  any IP/CIDR no-proxy rule (operator bypass rule ignored for portless hosts).
  Fixed and pinned by a committed regression seed.
- Behaviour-preserving RFC 4291 canonicalisation made explicit in `ipAllowed`
  (enables a sound netip differential oracle).
- **Zero new dependencies** — `httpproxy`/`httpguts` deliberately avoided
  (they transitively pull `golang.org/x/text`); oracles are clean-room stdlib.
- Nightly `Fuzz` workflow (matrix, 300s/target); regression replay runs free
  in the existing test job.
- Contributor + AI guidance added (`CONTRIBUTING.md` § Fuzzing, `CLAUDE.md`).

## Test plan

- [x] `go test -count=1 ./...` green (466)
- [x] `golangci-lint run` clean
- [x] `actionlint .github/workflows/fuzz.yml` clean
- [x] `go mod tidy` produces no dependency change
- [x] Each target fuzzed 30–90s locally, no remaining crash/divergence
- [x] Negative control: sabotaged predicate confirmed a target catches it
- [ ] CI green on this PR
- [ ] Post-merge: scheduled `Fuzz` workflow dispatch succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)