### PR TITLE
refactor: dedupe IPv6 bracket strip; tidy fuzz idioms/comments

### DIFF
--- a/config.go
+++ b/config.go
@@ -123,9 +123,7 @@ func ipAllowed(ip net.IP, allowList []*net.IPNet) bool {
 	}
 	// RFC 4291: an IPv4-mapped IPv6 address denotes the same host as the bare
 	// IPv4 address. Canonicalise to the 4-byte form so allowlist identity is
-	// consistent regardless of which form the client connected with. (Behaviour
-	// is unchanged — net.IPNet.Contains already aligns families via To4 — but
-	// making it explicit documents the contract and pins it under fuzzing.)
+	// consistent regardless of which form the client connected with.
 	if v4 := ip.To4(); v4 != nil {
 		ip = v4
 	}

--- a/config_fuzz_test.go
+++ b/config_fuzz_test.go
@@ -9,12 +9,12 @@ import (
 )
 
 // FuzzConnectPortChain mirrors the production CONNECT port-gate chain
-// (prepareForwardRequest, forward.go:40-49): the client-controlled authority
-// is split by net.SplitHostPort, defaulting to "443" on error, and the port is
-// checked against the configured allow set.
+// (prepareForwardRequest): the client-controlled authority is split by
+// net.SplitHostPort, defaulting to "443" on error, and the port is checked
+// against the configured allow set.
 //
 // The oracle is the security-direction implication only — connectPortAllowed
-// does a pure byte-wise string compare (config.go:135), so a numeric/uint16
+// does a pure byte-wise string compare, so a numeric/uint16
 // equivalence oracle would be unsound (it would false-positive on "0443",
 // "+443", etc., which the function correctly rejects). The sound, security-
 // relevant property is: an accepted port under a non-empty, non-wildcard allow

--- a/direct.go
+++ b/direct.go
@@ -12,6 +12,17 @@ import (
 	"time"
 )
 
+// stripIPv6Brackets removes one surrounding "[]" pair from a bare bracketed
+// IPv6 literal that has no port (e.g. "[::1]" -> "::1"). It is a no-op for any
+// other input. Used on host-canonicalisation paths where net.SplitHostPort has
+// already failed (no port present).
+func stripIPv6Brackets(host string) string {
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		return host[1 : len(host)-1]
+	}
+	return host
+}
+
 // sameHost reports whether two HTTP Host values refer to the same
 // target. It canonicalises by lower-casing and applying defaultPort when a
 // host has no explicit port. Bracketed IPv6 addresses without a port (e.g.
@@ -24,11 +35,8 @@ func sameHost(a, b, defaultPort string) bool {
 		if err != nil {
 			host = h
 			port = defaultPort
-			// Bare bracketed IPv6 address with no port: strip brackets so
-			// net.JoinHostPort below re-adds them exactly once.
-			if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
-				host = host[1 : len(host)-1]
-			}
+			// Strip brackets so net.JoinHostPort below re-adds them once.
+			host = stripIPv6Brackets(host)
 		}
 		return net.JoinHostPort(host, port)
 	}

--- a/direct_fuzz_test.go
+++ b/direct_fuzz_test.go
@@ -11,7 +11,7 @@ import (
 // true-decisions. It deliberately differs from production (independent bracket
 // stripping; explicit netip normalisation of IP literals) so a collision bug
 // in production's canon — two genuinely different hosts treated as the same,
-// the response/request-smuggling vector at direct.go:104-110 — is caught.
+// the request-smuggling vector in handleDirectHTTP — is caught.
 func sameHostRef(h, defaultPort string) string {
 	h = strings.ToLower(strings.TrimSpace(h))
 	host, port, err := net.SplitHostPort(h)
@@ -30,7 +30,7 @@ func sameHostRef(h, defaultPort string) string {
 // FuzzSameHost guards the keep-alive connection binding in handleDirectHTTP:
 // sameHost falsely reporting two different hosts as equal lets a smuggled
 // pipelined request ride a direct connection bound to a different,
-// unauthorised host (direct.go:104-110).
+// unauthorised host (the keep-alive binding in handleDirectHTTP).
 //
 // Assertions:
 //   - never panics;

--- a/noproxy.go
+++ b/noproxy.go
@@ -77,11 +77,10 @@ func (m *NoProxyMatcher) Match(host string) (matched bool, pattern string) {
 	// Strip port if present.
 	if h, _, err := net.SplitHostPort(host); err == nil {
 		host = h
-	} else if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
-		// Bare bracketed IPv6 literal with no port (e.g. "[::1]"): strip the
-		// brackets so it parses as an IP for IP/CIDR rule matching, mirroring
-		// sameHost in direct.go.
-		host = host[1 : len(host)-1]
+	} else {
+		// Bare bracketed IPv6 literal with no port must lose its brackets to
+		// parse as an IP for IP/CIDR rule matching.
+		host = stripIPv6Brackets(host)
 	}
 	host = strings.ToLower(host)
 

--- a/noproxy_fuzz_test.go
+++ b/noproxy_fuzz_test.go
@@ -78,7 +78,7 @@ func differentiableHost(h string) bool {
 	if _, err := netip.ParseAddr(h); err == nil {
 		return true
 	}
-	for i := 0; i < len(h); i++ {
+	for i := range len(h) {
 		c := h[i]
 		switch {
 		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '.', c == '-':

--- a/response_fuzz_test.go
+++ b/response_fuzz_test.go
@@ -164,7 +164,7 @@ func FuzzHeaderByteValidators(f *testing.F) {
 		gotName := isValidFieldName(name)
 		wantName := name != ""
 		if wantName {
-			for i := 0; i < len(name); i++ {
+			for i := range len(name) {
 				if !isTcharByte(name[i]) {
 					wantName = false
 					break
@@ -177,7 +177,7 @@ func FuzzHeaderByteValidators(f *testing.F) {
 
 		gotVal := hasForbiddenFieldValueByte(value)
 		wantVal := false
-		for i := 0; i < len(value); i++ {
+		for i := range len(value) {
 			b := value[i]
 			if (b < 0x20 && b != '\t') || b == 0x7f {
 				wantVal = true


### PR DESCRIPTION
Post-merge cleanup of PR #222 (fuzz suite), from a /simplify review.

## Summary

- Extract the bracketed-IPv6-literal strip — duplicated verbatim between
  `NoProxyMatcher.Match` and `sameHost` (the latter's comment already pointed
  at the other copy) — into a shared `stripIPv6Brackets` helper.
- New fuzz index byte-loops switched to `for i := range len(...)` per the
  project's modern-Go convention.
- Dropped rot-prone `file.go:NN` citations from fuzz doc comments and the
  change-narration clause in `ipAllowed` (RFC 4291 / oracle-soundness WHY kept).

No behaviour change. Test-side oracle helpers deliberately left independent
(consolidating them would defeat the differential — the dedupe is
production↔production only).

## Test plan

- [x] `gofmt` clean, `golangci-lint run` 0 issues
- [x] `go test -count=1 ./...` green (466, incl. the IPv6 regression seed)
- [x] Refactored paths re-fuzzed: FuzzNoProxyMatch + FuzzSameHost, 1.5M+
      execs each, no divergence
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)