### PR TITLE
ci: migrate native fuzzing to ClusterFuzzLite (full gamut)

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,11 @@
+# ClusterFuzzLite build environment for spnego-proxy.
+#
+# Pinned by digest for supply-chain parity with the repo's SHA-pinned GitHub
+# Actions. The tag was `latest` at pin time; Dependabot's `docker` ecosystem
+# (see .github/dependabot.yml, directory /.clusterfuzzlite) keeps this digest
+# current. base-builder-go ships the Go toolchain plus the
+# `compile_native_go_fuzzer` helper used by build.sh.
+FROM gcr.io/oss-fuzz-base/base-builder-go@sha256:373fb2d9c584e046d58e3807435aa671fed7b8bd2300455f0c37402403b96f85
+
+COPY . $SRC/spnego-proxy
+WORKDIR $SRC/spnego-proxy

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -9,3 +9,7 @@ FROM gcr.io/oss-fuzz-base/base-builder-go@sha256:373fb2d9c584e046d58e3807435aa67
 
 COPY . $SRC/spnego-proxy
 WORKDIR $SRC/spnego-proxy
+
+# ClusterFuzzLite/OSS-Fuzz invokes $SRC/build.sh; the repo keeps it under
+# .clusterfuzzlite/, so stage it at the expected path.
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -15,8 +15,11 @@
 cd "$SRC/spnego-proxy"
 
 # Build-time-only shim (container copy of the module; not the committed repo).
-go install github.com/AdamKorcz/go-118-fuzz-build@latest
-go get github.com/AdamKorcz/go-118-fuzz-build/testing
+# Pinned for reproducible CFL builds (the module publishes no semver tags, only
+# pseudo-versions). Bump deliberately; keep both lines on the identical version.
+GO118_FUZZ_BUILD_VERSION=v0.0.0-20250520111509-a70c2aa677fa
+go install "github.com/AdamKorcz/go-118-fuzz-build@${GO118_FUZZ_BUILD_VERSION}"
+go get "github.com/AdamKorcz/go-118-fuzz-build/testing@${GO118_FUZZ_BUILD_VERSION}"
 
 # Fuzz targets live in package proxy at internal/proxy (extracted from
 # package main in PR #225 so ClusterFuzzLite can import them).

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -eu
+#
+# ClusterFuzzLite build script for spnego-proxy.
+#
+# Compiles the repo's 7 native `testing.F` fuzz targets into libFuzzer
+# binaries via OSS-Fuzz's `compile_native_go_fuzzer` helper.
+#
+# go.mod invariant: `compile_native_go_fuzzer` rewrites native targets through
+# the go-118-fuzz-build shim, which requires the shim be importable. The
+# `go get` below mutates ONLY the container's throwaway copy of the module;
+# the committed repo go.mod/go.sum are never touched, so the
+# "no new module dependency / `go mod tidy` no-diff" rule (CONTRIBUTING.md
+# § Fuzzing) still holds. Spike B in the migration plan asserts this.
+
+cd "$SRC/spnego-proxy"
+
+# Build-time-only shim (container copy of the module; not the committed repo).
+go install github.com/AdamKorcz/go-118-fuzz-build@latest
+go get github.com/AdamKorcz/go-118-fuzz-build/testing
+
+MODULE=github.com/andrewesweet/spnego-proxy
+
+compile_native_go_fuzzer "$MODULE" FuzzNoProxyMatch            fuzz_no_proxy_match
+compile_native_go_fuzzer "$MODULE" FuzzUpstreamResponseFraming fuzz_upstream_response_framing
+compile_native_go_fuzzer "$MODULE" FuzzConnectPortChain        fuzz_connect_port_chain
+compile_native_go_fuzzer "$MODULE" FuzzSameHost                fuzz_same_host
+compile_native_go_fuzzer "$MODULE" FuzzIPAllowlistChain        fuzz_ip_allowlist_chain
+compile_native_go_fuzzer "$MODULE" FuzzContentLengthValues     fuzz_content_length_values
+compile_native_go_fuzzer "$MODULE" FuzzHeaderByteValidators    fuzz_header_byte_validators
+
+# Carry the committed Go regression seed into the ClusterFuzzLite corpus so a
+# fresh storage repo starts from the known FuzzNoProxyMatch reproducer.
+if [ -d testdata/fuzz/FuzzNoProxyMatch ]; then
+  zip -j "$OUT/fuzz_no_proxy_match_seed_corpus.zip" testdata/fuzz/FuzzNoProxyMatch/*
+fi

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -18,18 +18,20 @@ cd "$SRC/spnego-proxy"
 go install github.com/AdamKorcz/go-118-fuzz-build@latest
 go get github.com/AdamKorcz/go-118-fuzz-build/testing
 
-MODULE=github.com/andrewesweet/spnego-proxy
+# Fuzz targets live in package proxy at internal/proxy (extracted from
+# package main in PR #225 so ClusterFuzzLite can import them).
+PKG=github.com/andrewesweet/spnego-proxy/internal/proxy
 
-compile_native_go_fuzzer "$MODULE" FuzzNoProxyMatch            fuzz_no_proxy_match
-compile_native_go_fuzzer "$MODULE" FuzzUpstreamResponseFraming fuzz_upstream_response_framing
-compile_native_go_fuzzer "$MODULE" FuzzConnectPortChain        fuzz_connect_port_chain
-compile_native_go_fuzzer "$MODULE" FuzzSameHost                fuzz_same_host
-compile_native_go_fuzzer "$MODULE" FuzzIPAllowlistChain        fuzz_ip_allowlist_chain
-compile_native_go_fuzzer "$MODULE" FuzzContentLengthValues     fuzz_content_length_values
-compile_native_go_fuzzer "$MODULE" FuzzHeaderByteValidators    fuzz_header_byte_validators
+compile_native_go_fuzzer "$PKG" FuzzNoProxyMatch            fuzz_no_proxy_match
+compile_native_go_fuzzer "$PKG" FuzzUpstreamResponseFraming fuzz_upstream_response_framing
+compile_native_go_fuzzer "$PKG" FuzzConnectPortChain        fuzz_connect_port_chain
+compile_native_go_fuzzer "$PKG" FuzzSameHost                fuzz_same_host
+compile_native_go_fuzzer "$PKG" FuzzIPAllowlistChain        fuzz_ip_allowlist_chain
+compile_native_go_fuzzer "$PKG" FuzzContentLengthValues     fuzz_content_length_values
+compile_native_go_fuzzer "$PKG" FuzzHeaderByteValidators    fuzz_header_byte_validators
 
 # Carry the committed Go regression seed into the ClusterFuzzLite corpus so a
 # fresh storage repo starts from the known FuzzNoProxyMatch reproducer.
-if [ -d testdata/fuzz/FuzzNoProxyMatch ]; then
-  zip -j "$OUT/fuzz_no_proxy_match_seed_corpus.zip" testdata/fuzz/FuzzNoProxyMatch/*
+if [ -d internal/proxy/testdata/fuzz/FuzzNoProxyMatch ]; then
+  zip -j "$OUT/fuzz_no_proxy_match_seed_corpus.zip" internal/proxy/testdata/fuzz/FuzzNoProxyMatch/*
 fi

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -21,8 +21,8 @@ GO118_FUZZ_BUILD_VERSION=v0.0.0-20250520111509-a70c2aa677fa
 go install "github.com/AdamKorcz/go-118-fuzz-build@${GO118_FUZZ_BUILD_VERSION}"
 go get "github.com/AdamKorcz/go-118-fuzz-build/testing@${GO118_FUZZ_BUILD_VERSION}"
 
-# Fuzz targets live in package proxy at internal/proxy (extracted from
-# package main in PR #225 so ClusterFuzzLite can import them).
+# compile_native_go_fuzzer imports the target by path; package main is not
+# importable, so the targets live in the internal/proxy package.
 PKG=github.com/andrewesweet/spnego-proxy/internal/proxy
 
 compile_native_go_fuzzer "$PKG" FuzzNoProxyMatch            fuzz_no_proxy_match
@@ -35,6 +35,11 @@ compile_native_go_fuzzer "$PKG" FuzzHeaderByteValidators    fuzz_header_byte_val
 
 # Carry the committed Go regression seed into the ClusterFuzzLite corpus so a
 # fresh storage repo starts from the known FuzzNoProxyMatch reproducer.
-if [ -d internal/proxy/testdata/fuzz/FuzzNoProxyMatch ]; then
-  zip -j "$OUT/fuzz_no_proxy_match_seed_corpus.zip" internal/proxy/testdata/fuzz/FuzzNoProxyMatch/*
+# nullglob: an empty seed dir must yield zero args, not a literal glob under
+# `set -e` (which would fail zip and abort the build).
+shopt -s nullglob
+seeds=(internal/proxy/testdata/fuzz/FuzzNoProxyMatch/*)
+shopt -u nullglob
+if [ ${#seeds[@]} -gt 0 ]; then
+  zip -j "$OUT/fuzz_no_proxy_match_seed_corpus.zip" "${seeds[@]}"
 fi

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,5 @@
+language: go
+# AddressSanitizer is the only sanitizer valid for Go. Coverage is produced
+# separately via run_fuzzers `mode: coverage` (see .github/workflows/cflite_batch.yml).
+sanitizers:
+  - address

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,14 @@ updates:
           - "*"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "docker"
+    directory: "/.clusterfuzzlite"
+    schedule:
+      interval: "weekly"
+    groups:
+      docker:
+        patterns:
+          - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,0 +1,152 @@
+name: ClusterFuzzLite Batch
+
+# Nightly deep fuzzing. Three sequential jobs share one storage repo:
+#   batch  -> grows the corpus (fuzz-seconds 3600 across all targets)
+#   prune  -> trims redundant corpus entries (mandatory companion to batch)
+#   coverage -> publishes an HTML report to the storage repo's gh-pages branch
+# `needs:` guarantees ordering; the cflite-storage concurrency group serialises
+# against the continuous-build workflow so corpus writes never race.
+# Storage auth is an SSH deploy key (mirrors update-homebrew.yml), never a PAT.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cflite-storage
+  cancel-in-progress: false
+
+env:
+  STORAGE_REPO: git@github.com:andrewesweet/spnego-proxy-fuzz-corpus.git
+
+jobs:
+  batch:
+    name: batch fuzzing
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up SSH for storage deploy key
+        env:
+          DEPLOY_KEY: ${{ secrets.FUZZ_CORPUS_DEPLOY_KEY }}
+        run: |
+          if [ -z "${DEPLOY_KEY}" ]; then
+            echo "::error::FUZZ_CORPUS_DEPLOY_KEY secret is not configured"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          echo "${DEPLOY_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global core.sshCommand "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes"
+
+      - name: Build fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: address
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          storage-repo: ${{ env.STORAGE_REPO }}
+          storage-repo-branch: main
+
+      - name: Run batch fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          language: go
+          mode: batch
+          fuzz-seconds: 3600
+          sanitizer: address
+          storage-repo: ${{ env.STORAGE_REPO }}
+          storage-repo-branch: main
+
+      - name: Clean up SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key
+
+  prune:
+    name: corpus pruning
+    needs: batch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up SSH for storage deploy key
+        env:
+          DEPLOY_KEY: ${{ secrets.FUZZ_CORPUS_DEPLOY_KEY }}
+        run: |
+          if [ -z "${DEPLOY_KEY}" ]; then
+            echo "::error::FUZZ_CORPUS_DEPLOY_KEY secret is not configured"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          echo "${DEPLOY_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global core.sshCommand "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes"
+
+      - name: Build fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: address
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          storage-repo: ${{ env.STORAGE_REPO }}
+          storage-repo-branch: main
+
+      - name: Prune corpus
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          language: go
+          mode: prune
+          sanitizer: address
+          storage-repo: ${{ env.STORAGE_REPO }}
+          storage-repo-branch: main
+
+      - name: Clean up SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key
+
+  coverage:
+    name: coverage report
+    needs: prune
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up SSH for storage deploy key
+        env:
+          DEPLOY_KEY: ${{ secrets.FUZZ_CORPUS_DEPLOY_KEY }}
+        run: |
+          if [ -z "${DEPLOY_KEY}" ]; then
+            echo "::error::FUZZ_CORPUS_DEPLOY_KEY secret is not configured"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          echo "${DEPLOY_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global core.sshCommand "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes"
+
+      - name: Build fuzzers (coverage)
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: coverage
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          storage-repo: ${{ env.STORAGE_REPO }}
+          storage-repo-branch: main
+
+      - name: Generate coverage report
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          language: go
+          mode: coverage
+          sanitizer: coverage
+          storage-repo: ${{ env.STORAGE_REPO }}
+          storage-repo-branch: main
+          storage-repo-branch-coverage: gh-pages
+
+      - name: Clean up SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -12,6 +12,11 @@ on:
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:
+    inputs:
+      fuzz_seconds:
+        description: 'Batch fuzzing seconds (lower for fast on-demand storage / deploy-key checks)'
+        required: false
+        default: '3600'
 
 permissions:
   contents: read
@@ -57,7 +62,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           language: go
           mode: batch
-          fuzz-seconds: 3600
+          fuzz-seconds: ${{ github.event.inputs.fuzz_seconds || '3600' }}
           sanitizer: address
           storage-repo: ${{ env.STORAGE_REPO }}
           storage-repo-branch: main

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -62,6 +62,9 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           language: go
           mode: batch
+          # On schedule, github.event.inputs.fuzz_seconds is '' (falsy), so the
+          # || fallback yields 3600. The input's declared default only pre-fills
+          # the manual-dispatch UI; it does not feed this expression.
           fuzz-seconds: ${{ github.event.inputs.fuzz_seconds || '3600' }}
           sanitizer: address
           storage-repo: ${{ env.STORAGE_REPO }}

--- a/.github/workflows/cflite_cont.yml
+++ b/.github/workflows/cflite_cont.yml
@@ -1,0 +1,56 @@
+name: ClusterFuzzLite Continuous Build
+
+# Rebuilds fuzzers on every push to master and syncs the corpus to the separate
+# storage repo. Storage auth is an SSH deploy key (mirrors update-homebrew.yml),
+# never a PAT — no token is embedded in a git URL or leaked to logs.
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.clusterfuzzlite/**'
+      - '.github/workflows/cflite_cont.yml'
+
+permissions:
+  contents: read
+
+# Serialise every storage-repo writer (this + the nightly batch) so corpus
+# pushes never race on the storage branch.
+concurrency:
+  group: cflite-storage
+  cancel-in-progress: false
+
+jobs:
+  continuous-build:
+    name: build + seed corpus
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up SSH for storage deploy key
+        env:
+          DEPLOY_KEY: ${{ secrets.FUZZ_CORPUS_DEPLOY_KEY }}
+        run: |
+          if [ -z "${DEPLOY_KEY}" ]; then
+            echo "::error::FUZZ_CORPUS_DEPLOY_KEY secret is not configured"
+            exit 1
+          fi
+          mkdir -p ~/.ssh
+          echo "${DEPLOY_KEY}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan github.com >> ~/.ssh/known_hosts
+          git config --global core.sshCommand "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes"
+
+      - name: Build fuzzers and sync corpus
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: address
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          storage-repo: git@github.com:andrewesweet/spnego-proxy-fuzz-corpus.git
+          storage-repo-branch: main
+
+      - name: Clean up SSH key
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/.github/workflows/cflite_cont.yml
+++ b/.github/workflows/cflite_cont.yml
@@ -26,6 +26,9 @@ concurrency:
   group: cflite-storage
   cancel-in-progress: false
 
+env:
+  STORAGE_REPO: git@github.com:andrewesweet/spnego-proxy-fuzz-corpus.git
+
 jobs:
   continuous-build:
     name: build + seed corpus
@@ -51,7 +54,7 @@ jobs:
           language: go
           sanitizer: address
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          storage-repo: git@github.com:andrewesweet/spnego-proxy-fuzz-corpus.git
+          storage-repo: ${{ env.STORAGE_REPO }}
           storage-repo-branch: main
 
       - name: Clean up SSH key

--- a/.github/workflows/cflite_cont.yml
+++ b/.github/workflows/cflite_cont.yml
@@ -13,6 +13,9 @@ on:
       - 'go.sum'
       - '.clusterfuzzlite/**'
       - '.github/workflows/cflite_cont.yml'
+  # On-demand: fast SSH-deploy-key / storage round-trip check (build + corpus
+  # sync only, no fuzzing) without waiting for a push to master.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,42 @@
+name: ClusterFuzzLite PR
+
+# Code-change fuzzing on pull requests. Fork-safe: uses `pull_request` (never
+# `pull_request_target`), the read-only default GITHUB_TOKEN, and NO storage
+# repo / deploy key, so a malicious fork PR cannot reach the corpus repo.
+# A discovered crash fails this check and uploads the reproducer as an artifact.
+#
+# No explicit actions/checkout: the ClusterFuzzLite build_fuzzers action manages
+# its own checkout (base + PR refs) to diff changed code for code-change mode.
+
+on:
+  pull_request:
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
+      - '.clusterfuzzlite/**'
+      - '.github/workflows/cflite_pr.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  pr-fuzzing:
+    name: code-change
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build fuzzers
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: address
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Run fuzzers
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          language: go
+          fuzz-seconds: 600
+          mode: code-change
+          sanitizer: address

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,16 @@ Key details for AI context:
   `[]byte`/`string`/scalars (OSS-Fuzz portable)
 - Real bug → `fix:` + commit reproducer as regression seed. Unsound oracle →
   tighten predicate and delete the noise reproducer (never commit it)
-- Add every new `Fuzz*` name to the matrix in `.github/workflows/fuzz.yml`
+- ClusterFuzzLite runs the same targets: `cflite_pr.yml` (PR code-change,
+  fork-safe, no storage), `cflite_cont.yml` (corpus seed on push to master),
+  `cflite_batch.yml` (nightly batch → prune → coverage). Build integration in
+  `.clusterfuzzlite/{project.yaml,Dockerfile,build.sh}`; corpus/crashes/coverage
+  in separate repo `andrewesweet/spnego-proxy-fuzz-corpus` via the
+  `FUZZ_CORPUS_DEPLOY_KEY` SSH deploy key (never a PAT)
+- Register every new `Fuzz*` with a `compile_native_go_fuzzer` line in
+  `.clusterfuzzlite/build.sh`. Legacy `.github/workflows/fuzz.yml` retained
+  until the CFL batch is validated, then removed; while present, add the name
+  to its matrix too
 
 ## Release Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,8 +84,17 @@ The proxy has native Go fuzz targets (`go test -fuzz`) covering the inputs an
 unprivileged client or a malicious origin controls. Seed corpora live in
 `f.Add` calls; discovered crash reproducers are committed under
 `internal/proxy/testdata/fuzz/<Target>/` and replayed for free by the ordinary
-`go test ./...` run (so a fixed bug stays fixed). The `Fuzz` workflow runs
-time-boxed discovery nightly.
+`go test ./...` run (so a fixed bug stays fixed).
+
+The same targets are continuously fuzzed by **ClusterFuzzLite** on GitHub
+Actions: code-change fuzzing on every PR (`cflite_pr.yml`, fork-safe, no
+storage), corpus seeding on push to `master` (`cflite_cont.yml`), and a nightly
+batch → prune → coverage pipeline (`cflite_batch.yml`). Corpus, crashes, and
+the coverage report live in a **separate storage repo**
+(`andrewesweet/spnego-proxy-fuzz-corpus`); the workflows authenticate to it
+with the `FUZZ_CORPUS_DEPLOY_KEY` SSH deploy-key secret (same pattern as the
+Homebrew tap — never a PAT). Build integration lives in `.clusterfuzzlite/`
+(`project.yaml`, `Dockerfile`, `build.sh`).
 
 Run one target locally:
 
@@ -123,14 +132,18 @@ library directly (the Go team already does) — fuzz *our* logic, optionally
    sound oracle, ship the target as no-panic / invariant-only.
 3. **OSS-Fuzz portable.** Entropy only via `[]byte`/`string`/scalars in
    `f.Fuzz`; targets must be hermetic and deterministic (no network, files,
-   clock, randomness, global state) and build with `CGO_ENABLED=0`. This keeps
-   ClusterFuzzLite / OSS-Fuzz a future drop-in with no target rewrite.
+   clock, randomness, global state) and build with `CGO_ENABLED=0`. This is
+   what lets ClusterFuzzLite compile the native targets unchanged via
+   `compile_native_go_fuzzer`.
 4. **Reproducer hygiene.** If a target fails: a *real* bug → fix the production
    code and commit the reproducer (it becomes a regression seed) with a `fix:`
    commit; an *unsound oracle* → tighten the predicate and **delete** the noise
    reproducer (do not commit it).
-5. **Register the target.** Add every new `Fuzz*` function name to the matrix
-   in `.github/workflows/fuzz.yml` so nightly discovery covers it.
+5. **Register the target.** Add a `compile_native_go_fuzzer` line for every new
+   `Fuzz*` function in `.clusterfuzzlite/build.sh` so ClusterFuzzLite builds it.
+   The legacy nightly `Fuzz` workflow (`.github/workflows/fuzz.yml`) is retained
+   until the ClusterFuzzLite batch is validated against the storage repo, then
+   removed; while it exists, also add the name to its matrix.
 
 ## Formatting
 


### PR DESCRIPTION
Migrates the 7 native `testing.F` targets onto **ClusterFuzzLite** while
keeping zero-cost regression replay (`go test ./...`) and the repo's
no-PAT / SHA-pin posture. GitHub Actions stays the CI/CD system.

## What this adds

- `.clusterfuzzlite/{project.yaml,Dockerfile,build.sh}` — base image
  digest-pinned, CFL actions commit-pinned (`884713a6… # v1`), go-118
  shim provisioned in-container only (committed `go.mod` untouched).
- `cflite_pr.yml` — code-change fuzzing per PR. **Fork-safe**:
  `pull_request`, read-only `GITHUB_TOKEN`, no storage, no secrets.
- `cflite_cont.yml` — corpus seed on push to `master`.
- `cflite_batch.yml` — nightly batch → prune → coverage, `needs:`-chained
  under one `cflite-storage` concurrency group.
- Storage auth = `FUZZ_CORPUS_DEPLOY_KEY` SSH deploy key (Homebrew-tap
  pattern), **never a PAT**.
- Dependabot `docker` ecosystem for `/.clusterfuzzlite`.
- CONTRIBUTING.md / CLAUDE.md updated.

## Deliberate: `fuzz.yml` retained

Native nightly `fuzz.yml` is **kept** to avoid a coverage gap. Retiring it
+ doc cleanup is a fast-follow once a green nightly CFL batch is confirmed
against the real storage repo.

## Blocked prerequisites (maintainer, before merge to master)

- [ ] Create repo `andrewesweet/spnego-proxy-fuzz-corpus` (public; `main`; orphan `gh-pages`)
- [ ] Add write-enabled SSH **deploy key** on that repo
- [ ] Add private key as secret **`FUZZ_CORPUS_DEPLOY_KEY`** here
- [ ] (Optional) Enable Pages on `gh-pages` for coverage HTML

`cflite_pr.yml` needs none of the above and runs on this draft PR now —
de-risks the Go build integration before the storage repo exists.

## Unknowns to validate in live CI

- **Spike A** — SSH-URL `storage-repo` across CFL git sync (fallback:
  PAT scoped solely to the storage repo).
- **Spike B** — `compile_native_go_fuzzer` keeps committed `go.mod`
  clean; all 7 `f.Fuzz` signatures build under the shim.

## Verification done

actionlint PASS · zizmor clean (regular persona) · shellcheck `build.sh`
clean · `go.mod`/`go.sum` unchanged · `cflite_pr.yml` confirmed
fork-safe. No release bump (`build:`/`ci:`/`docs:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)