### PR TITLE
ci: ClusterFuzzLite storage auth — SSH deploy key → fine-grained PAT

### DIFF
--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -6,7 +6,11 @@ name: ClusterFuzzLite Batch
 #   coverage -> publishes an HTML report to the storage repo's gh-pages branch
 # `needs:` guarantees ordering; the cflite-storage concurrency group serialises
 # against the continuous-build workflow so corpus writes never race.
-# Storage auth is an SSH deploy key (mirrors update-homebrew.yml), never a PAT.
+#
+# ClusterFuzzLite clones the storage repo inside the OSS-Fuzz build container
+# (no ssh, host ~/.ssh not mounted), so SSH deploy keys are unusable here.
+# Auth is a fine-grained PAT scoped to ONLY spnego-proxy-fuzz-corpus
+# (contents: read/write), secret FUZZ_CORPUS_TOKEN; GitHub masks it in logs.
 
 on:
   schedule:
@@ -14,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       fuzz_seconds:
-        description: 'Batch fuzzing seconds (lower for fast on-demand storage / deploy-key checks)'
+        description: 'Batch fuzzing seconds (lower for fast on-demand storage checks)'
         required: false
         default: '3600'
 
@@ -26,27 +30,13 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  STORAGE_REPO: git@github.com:andrewesweet/spnego-proxy-fuzz-corpus.git
+  STORAGE_REPO: https://x-access-token:${{ secrets.FUZZ_CORPUS_TOKEN }}@github.com/andrewesweet/spnego-proxy-fuzz-corpus.git
 
 jobs:
   batch:
     name: batch fuzzing
     runs-on: ubuntu-latest
     steps:
-      - name: Set up SSH for storage deploy key
-        env:
-          DEPLOY_KEY: ${{ secrets.FUZZ_CORPUS_DEPLOY_KEY }}
-        run: |
-          if [ -z "${DEPLOY_KEY}" ]; then
-            echo "::error::FUZZ_CORPUS_DEPLOY_KEY secret is not configured"
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          echo "${DEPLOY_KEY}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config --global core.sshCommand "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes"
-
       - name: Build fuzzers
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
@@ -70,29 +60,11 @@ jobs:
           storage-repo: ${{ env.STORAGE_REPO }}
           storage-repo-branch: main
 
-      - name: Clean up SSH key
-        if: always()
-        run: rm -f ~/.ssh/deploy_key
-
   prune:
     name: corpus pruning
     needs: batch
     runs-on: ubuntu-latest
     steps:
-      - name: Set up SSH for storage deploy key
-        env:
-          DEPLOY_KEY: ${{ secrets.FUZZ_CORPUS_DEPLOY_KEY }}
-        run: |
-          if [ -z "${DEPLOY_KEY}" ]; then
-            echo "::error::FUZZ_CORPUS_DEPLOY_KEY secret is not configured"
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          echo "${DEPLOY_KEY}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config --global core.sshCommand "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes"
-
       - name: Build fuzzers
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
@@ -112,29 +84,11 @@ jobs:
           storage-repo: ${{ env.STORAGE_REPO }}
           storage-repo-branch: main
 
-      - name: Clean up SSH key
-        if: always()
-        run: rm -f ~/.ssh/deploy_key
-
   coverage:
     name: coverage report
     needs: prune
     runs-on: ubuntu-latest
     steps:
-      - name: Set up SSH for storage deploy key
-        env:
-          DEPLOY_KEY: ${{ secrets.FUZZ_CORPUS_DEPLOY_KEY }}
-        run: |
-          if [ -z "${DEPLOY_KEY}" ]; then
-            echo "::error::FUZZ_CORPUS_DEPLOY_KEY secret is not configured"
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          echo "${DEPLOY_KEY}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config --global core.sshCommand "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes"
-
       - name: Build fuzzers (coverage)
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
@@ -154,7 +108,3 @@ jobs:
           storage-repo: ${{ env.STORAGE_REPO }}
           storage-repo-branch: main
           storage-repo-branch-coverage: gh-pages
-
-      - name: Clean up SSH key
-        if: always()
-        run: rm -f ~/.ssh/deploy_key

--- a/.github/workflows/cflite_cont.yml
+++ b/.github/workflows/cflite_cont.yml
@@ -1,8 +1,11 @@
 name: ClusterFuzzLite Continuous Build
 
 # Rebuilds fuzzers on every push to master and syncs the corpus to the separate
-# storage repo. Storage auth is an SSH deploy key (mirrors update-homebrew.yml),
-# never a PAT — no token is embedded in a git URL or leaked to logs.
+# storage repo. ClusterFuzzLite clones the storage repo *inside* the OSS-Fuzz
+# build container (no ssh binary, host ~/.ssh not mounted), so an SSH deploy
+# key cannot work here — auth is a fine-grained PAT scoped to ONLY
+# spnego-proxy-fuzz-corpus (contents: read/write), secret FUZZ_CORPUS_TOKEN.
+# GitHub masks the secret in logs; the corpus repo holds non-sensitive data.
 
 on:
   push:
@@ -13,8 +16,8 @@ on:
       - 'go.sum'
       - '.clusterfuzzlite/**'
       - '.github/workflows/cflite_cont.yml'
-  # On-demand: fast SSH-deploy-key / storage round-trip check (build + corpus
-  # sync only, no fuzzing) without waiting for a push to master.
+  # On-demand: fast storage round-trip check (build + corpus sync, no fuzzing)
+  # without waiting for a push to master.
   workflow_dispatch:
 
 permissions:
@@ -27,27 +30,13 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  STORAGE_REPO: git@github.com:andrewesweet/spnego-proxy-fuzz-corpus.git
+  STORAGE_REPO: https://x-access-token:${{ secrets.FUZZ_CORPUS_TOKEN }}@github.com/andrewesweet/spnego-proxy-fuzz-corpus.git
 
 jobs:
   continuous-build:
     name: build + seed corpus
     runs-on: ubuntu-latest
     steps:
-      - name: Set up SSH for storage deploy key
-        env:
-          DEPLOY_KEY: ${{ secrets.FUZZ_CORPUS_DEPLOY_KEY }}
-        run: |
-          if [ -z "${DEPLOY_KEY}" ]; then
-            echo "::error::FUZZ_CORPUS_DEPLOY_KEY secret is not configured"
-            exit 1
-          fi
-          mkdir -p ~/.ssh
-          echo "${DEPLOY_KEY}" > ~/.ssh/deploy_key
-          chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config --global core.sshCommand "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes"
-
       - name: Build fuzzers and sync corpus
         uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
         with:
@@ -56,7 +45,3 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           storage-repo: ${{ env.STORAGE_REPO }}
           storage-repo-branch: main
-
-      - name: Clean up SSH key
-        if: always()
-        run: rm -f ~/.ssh/deploy_key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,8 +138,10 @@ Key details for AI context:
   fork-safe, no storage), `cflite_cont.yml` (corpus seed on push to master),
   `cflite_batch.yml` (nightly batch → prune → coverage). Build integration in
   `.clusterfuzzlite/{project.yaml,Dockerfile,build.sh}`; corpus/crashes/coverage
-  in separate repo `andrewesweet/spnego-proxy-fuzz-corpus` via the
-  `FUZZ_CORPUS_DEPLOY_KEY` SSH deploy key (never a PAT)
+  in separate repo `andrewesweet/spnego-proxy-fuzz-corpus`. CFL clones the
+  storage repo inside the OSS-Fuzz container (no ssh there), so auth is a
+  fine-grained PAT scoped to ONLY that repo (contents RW), secret
+  `FUZZ_CORPUS_TOKEN` — not an SSH deploy key
 - Register every new `Fuzz*` with a `compile_native_go_fuzzer` line in
   `.clusterfuzzlite/build.sh`. Legacy `.github/workflows/fuzz.yml` retained
   until the CFL batch is validated, then removed; while present, add the name

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,10 +91,15 @@ Actions: code-change fuzzing on every PR (`cflite_pr.yml`, fork-safe, no
 storage), corpus seeding on push to `master` (`cflite_cont.yml`), and a nightly
 batch → prune → coverage pipeline (`cflite_batch.yml`). Corpus, crashes, and
 the coverage report live in a **separate storage repo**
-(`andrewesweet/spnego-proxy-fuzz-corpus`); the workflows authenticate to it
-with the `FUZZ_CORPUS_DEPLOY_KEY` SSH deploy-key secret (same pattern as the
-Homebrew tap — never a PAT). Build integration lives in `.clusterfuzzlite/`
-(`project.yaml`, `Dockerfile`, `build.sh`).
+(`andrewesweet/spnego-proxy-fuzz-corpus`). ClusterFuzzLite clones the storage
+repo *inside* the OSS-Fuzz build container, where there is no `ssh` binary and
+the runner's `~/.ssh` is not mounted, so an SSH deploy key cannot be used
+here (unlike the Homebrew tap, whose clone is host-side). The workflows
+authenticate with a **fine-grained PAT scoped to only the corpus repo**
+(Contents: read/write), stored as the `FUZZ_CORPUS_TOKEN` secret; GitHub masks
+it in logs and the repo holds non-sensitive corpus/coverage data. Build
+integration lives in `.clusterfuzzlite/` (`project.yaml`, `Dockerfile`,
+`build.sh`).
 
 Run one target locally:
 


### PR DESCRIPTION
## Why

Spike A (post-#224 merge, run [25974306541](https://github.com/andrewesweet/spnego-proxy/actions/runs/25974306541)) proved the SSH-deploy-key approach **cannot work** with ClusterFuzzLite:

```
error: cannot run ssh: No such file or directory
fatal: unable to fork
git clone git@github.com:andrewesweet/spnego-proxy-fuzz-corpus.git . → exit 128
```

CFL clones the storage repo **inside the OSS-Fuzz build container** (`gcr.io/oss-fuzz-base/clusterfuzzlite-build-fuzzers:v1`) — no `ssh` binary, and the action does not mount the runner's `~/.ssh`/git config. The host-side deploy key is unreachable. The pinned third-party action can't be changed.

## Change

- `cflite_cont.yml` / `cflite_batch.yml`: storage auth → HTTPS with a **fine-grained PAT scoped to only `spnego-proxy-fuzz-corpus`** (Contents: read/write), secret `FUZZ_CORPUS_TOKEN`. All four host-side SSH setup/cleanup blocks removed (workflows much simpler).
- `update-homebrew.yml` unaffected — its clone is host-side, SSH works there. Issue #226 (ssh-keyscan hardening) now narrows to homebrew only.
- Docs (`CLAUDE.md`, `CONTRIBUTING.md`) corrected.

## Required before merge (maintainer)

1. Create a **fine-grained PAT**: Resource owner `andrewesweet`, repository access = **only** `spnego-proxy-fuzz-corpus`, permission **Contents: Read and write** (nothing else).
2. `gh secret set FUZZ_CORPUS_TOKEN --repo andrewesweet/spnego-proxy` (paste the token at the prompt — do not share it).
3. Optional cleanup: delete the now-unused `FUZZ_CORPUS_DEPLOY_KEY` secret and the storage-repo deploy key.

After merge, the master push auto-runs `cflite_cont` (re-validates Spike A); then `gh workflow run cflite_batch.yml --ref master -f fuzz_seconds=60` validates the full chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)