### PR TITLE
ci(security): pin GitHub SSH host keys from api.github.com/meta

### DIFF
--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -68,8 +68,18 @@ jobs:
           mkdir -p ~/.ssh
           echo "${DEPLOY_KEY}" > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
-          ssh-keyscan github.com >> ~/.ssh/known_hosts
-          git config --global core.sshCommand "ssh -i ~/.ssh/deploy_key -o StrictHostKeyChecking=yes"
+          # Pin GitHub's host keys from the authenticated HTTPS metadata API
+          # rather than trusting whatever the SSH path serves (ssh-keyscan is
+          # trust-on-first-use). Auto-adapts to GitHub host-key rotation. See
+          # issue #226.
+          curl -fsSL --retry 3 https://api.github.com/meta \
+            | jq -r '.ssh_keys[] | "github.com " + .' > ~/.ssh/known_hosts
+          if [ ! -s ~/.ssh/known_hosts ]; then
+            echo "::error::failed to fetch GitHub SSH host keys from api.github.com/meta"
+            exit 1
+          fi
+          chmod 644 ~/.ssh/known_hosts
+          git config --global core.sshCommand "ssh -i ~/.ssh/deploy_key -o UserKnownHostsFile=~/.ssh/known_hosts -o StrictHostKeyChecking=yes"
 
       - name: Clone tap repo
         run: git clone git@github.com:andrewesweet/homebrew-spnego-proxy.git /tmp/tap


### PR DESCRIPTION
Closes #226.

## Problem
`update-homebrew.yml` ran `ssh-keyscan github.com >> ~/.ssh/known_hosts` then `StrictHostKeyChecking=yes` — the host key is trusted from the same network/SSH path the check is supposed to defend (trust-on-first-use). CodeRabbit flagged this on #224; deferred and tracked as #226. ClusterFuzzLite has since moved off SSH entirely, so this is the **last** `ssh-keyscan` in the repo.

## Change
Fetch GitHub's published host keys from the authenticated HTTPS metadata API (`https://api.github.com/meta` → `.ssh_keys`), write them to a pinned `known_hosts`, and reference it via `UserKnownHostsFile` with `StrictHostKeyChecking=yes`.

- Trust anchor: GitHub web PKI + GitHub authority (not the SSH path).
- Auto-adapts to GitHub host-key rotation (the 2023 RSA rotation broke statically-pinned CIs) — no committed `known_hosts` to bump, no silent Homebrew-release breakage.
- `curl -f --retry 3` + a non-empty `known_hosts` guard fail the job loudly if the fetch is bad, rather than silently degrading.

## Verification
actionlint (incl. shellcheck) + zizmor clean locally. End-to-end exercised on the next release (or `workflow_dispatch` with `dry_run: true`, which still does the clone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)