### PR TITLE
fix(security): close on upstream drain failure; fix shutdown race

### DIFF
--- a/internal/proxy/connect.go
+++ b/internal/proxy/connect.go
@@ -73,6 +73,20 @@ func isExpectedCloseError(err error) bool {
 	return false
 }
 
+// logForwardError logs a data-forwarding error at the appropriate level:
+// Debug for routine connection teardown (see isExpectedCloseError), Error
+// otherwise. It is a no-op when err is nil.
+func logForwardError(err error, fromAddr, toAddr net.Addr) {
+	if err == nil {
+		return
+	}
+	if isExpectedCloseError(err) {
+		slog.Debug("forward closed", "error", err, "from", fromAddr, "to", toAddr)
+	} else {
+		slog.Error("forward error", "error", err, "from", fromAddr, "to", toAddr)
+	}
+}
+
 // forwardHalf copies data from src to dst, calling CloseWrite on dst when
 // done. It logs the start, completion, and any errors. Callers use
 // wg.Go to launch forwardHalf so the WaitGroup is managed automatically.
@@ -88,13 +102,7 @@ func forwardHalf(dst net.Conn, src io.Reader, srcConn net.Conn, fromAddr, toAddr
 	} else {
 		_, err = io.Copy(dst, src)
 	}
-	if err != nil {
-		if isExpectedCloseError(err) {
-			slog.Debug("forward closed", "error", err, "from", fromAddr, "to", toAddr)
-		} else {
-			slog.Error("forward error", "error", err, "from", fromAddr, "to", toAddr)
-		}
-	}
+	logForwardError(err, fromAddr, toAddr)
 }
 
 // handleConnectTunnel manages the CONNECT tunnel lifecycle per RFC 9110 §9.3.6.
@@ -118,11 +126,7 @@ func handleConnectTunnel(conn, proxyConn net.Conn, reqReader *bufio.Reader, req 
 		// Connection is cleaned up by deferred conn.Close() in
 		// handleClient (D5).
 		if err := resp.Write(conn); err != nil {
-			if isExpectedCloseError(err) {
-				slog.Debug("forward closed", "error", err, "from", proxyConn.RemoteAddr(), "to", conn.RemoteAddr())
-			} else {
-				slog.Error("forward error", "error", err, "from", proxyConn.RemoteAddr(), "to", conn.RemoteAddr())
-			}
+			logForwardError(err, proxyConn.RemoteAddr(), conn.RemoteAddr())
 		}
 		slog.Debug("upstream rejected CONNECT", "status", resp.StatusCode, "client_addr", clientAddr)
 		return
@@ -133,11 +137,7 @@ func handleConnectTunnel(conn, proxyConn net.Conn, reqReader *bufio.Reader, req 
 	// headers that cause Bun/undici clients to close the connection before
 	// the TLS handshake through the tunnel can begin.
 	if err := writeConnectOK(conn, resp); err != nil {
-		if isExpectedCloseError(err) {
-			slog.Debug("forward closed", "error", err, "from", proxyConn.RemoteAddr(), "to", conn.RemoteAddr())
-		} else {
-			slog.Error("forward error", "error", err, "from", proxyConn.RemoteAddr(), "to", conn.RemoteAddr())
-		}
+		logForwardError(err, proxyConn.RemoteAddr(), conn.RemoteAddr())
 		return
 	}
 

--- a/internal/proxy/direct.go
+++ b/internal/proxy/direct.go
@@ -159,7 +159,14 @@ func handleDirectHTTP(conn net.Conn, req *http.Request, reqReader *bufio.Reader,
 			}
 			return
 		}
-		_, _ = io.Copy(io.Discard, resp.Body)
+		// Drain so upstreamReader is aligned for the next iteration. A
+		// drain failure means the reader may be mid-body; reusing it
+		// risks response misframing, so close instead of looping.
+		if _, derr := io.Copy(io.Discard, resp.Body); derr != nil {
+			_ = resp.Body.Close()
+			slog.Debug("noproxy upstream body drain failed, closing connection", "error", derr, "target", target, "client_addr", clientAddr)
+			return
+		}
 		_ = resp.Body.Close()
 		slog.Debug("noproxy HTTP response forwarding done", "target", target, "client_addr", clientAddr, "iter", iter)
 

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -248,17 +248,19 @@ func handleClient(conn net.Conn, cfg Config) {
 		writeErr := resp.Write(conn)
 		if writeErr != nil {
 			_ = resp.Body.Close()
-			if isExpectedCloseError(writeErr) {
-				slog.Debug("forward closed", "error", writeErr, "from", proxyConn.RemoteAddr(), "to", conn.RemoteAddr())
-			} else {
-				slog.Error("forward error", "error", writeErr, "from", proxyConn.RemoteAddr(), "to", conn.RemoteAddr())
-			}
+			logForwardError(writeErr, proxyConn.RemoteAddr(), conn.RemoteAddr())
 			return
 		}
 		// Drain any unread body so upstreamReader is aligned for the
 		// next iteration; resp.Write already consumed it for well-framed
-		// responses.
-		_, _ = io.Copy(io.Discard, resp.Body)
+		// responses. If the drain fails the reader may be mid-body and
+		// reusing it for the next request risks response misframing —
+		// close the connection instead of continuing the keep-alive loop.
+		if _, derr := io.Copy(io.Discard, resp.Body); derr != nil {
+			_ = resp.Body.Close()
+			slog.Debug("upstream body drain failed, closing connection", "error", derr, "client_addr", clientAddr, "upstream_addr", cfg.Upstream)
+			return
+		}
 		_ = resp.Body.Close()
 
 		if connectionWillClose(req, resp) {

--- a/internal/proxy/headers.go
+++ b/internal/proxy/headers.go
@@ -59,11 +59,7 @@ func injectForwardingHeaders(req *http.Request, clientAddr string, fwdCfg Forwar
 
 	// H2/H3/H4
 	if fwdCfg.XForwardedForEnabled {
-		clientIP, _, err := net.SplitHostPort(clientAddr)
-		if err != nil {
-			slog.Debug("could not parse host:port from client address, using raw address", "client_addr", clientAddr, "error", err)
-			clientIP = clientAddr // fallback when address has no port component
-		}
+		clientIP := extractHost(clientAddr)
 		// H2
 		appendHeaderValue(req.Header, "X-Forwarded-For", clientIP)
 		// H3

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -15,7 +15,9 @@ import (
 // (netutil.LimitListener) applied by the caller.
 func Serve(ctx context.Context, l net.Listener, cfg Config, drainTimeout time.Duration) {
 	var wg sync.WaitGroup
+	acceptDone := make(chan struct{})
 	go func() {
+		defer close(acceptDone)
 		for {
 			conn, err := l.Accept()
 			if err != nil {
@@ -36,6 +38,10 @@ func Serve(ctx context.Context, l net.Listener, cfg Config, drainTimeout time.Du
 	<-ctx.Done()
 	slog.Info("shutting down, draining connections...")
 	_ = l.Close()
+	// Wait for the accept loop to observe the closed listener and stop
+	// before draining: this guarantees no further wg.Go can race with the
+	// wg.Wait below (a sync.WaitGroup add concurrent with Wait is a misuse).
+	<-acceptDone
 
 	done := make(chan struct{})
 	go func() { wg.Wait(); close(done) }()


### PR DESCRIPTION
## Summary

Hardening + dedup from a whole-codebase code review (reuse / quality / efficiency). No CLI-contract or log-format change — SemVer **patch**.

## Changes

- **`fix(security)` — keep-alive drain** (`forward.go`, `direct.go`): the unread-body drain error from `io.Copy(io.Discard, resp.Body)` was discarded, then the upstream `bufio.Reader` was reused for the next pipelined request. A mid-body reader risks response misframing. A drain error now closes the connection instead of continuing the keep-alive loop.
- **`fix` — shutdown race** (`server.go`): on `ctx` cancellation the accept loop could call `wg.Go` after the drain path's `wg.Wait` had begun — a `sync.WaitGroup` add concurrent with `Wait` is a misuse. An `acceptDone` barrier now blocks drain until the accept goroutine has observed the closed listener and stopped.
- **`refactor`** (`connect.go`, `forward.go`): extract `logForwardError` for the `isExpectedCloseError → Debug/Error` block duplicated across four call sites. Emitted log records are byte-identical.
- **`refactor`** (`headers.go`): replace a hand-rolled `net.SplitHostPort` with the existing `extractHost` helper; identical value.

## Verification

- `go build ./...` ✅  `go vet ./...` ✅
- `go test -count=1 ./...` → **476 pass** ✅
- `gofmt` clean, `go.mod`/`go.sum` unchanged (no new deps) ✅

## Out of scope (follow-up)

Stringly-typed HTTP header names across 5+ files — a typo silently disables a security strip. Warrants a dedicated, separately-reviewed change introducing header-name constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)