### PR TITLE
refactor: replace HTTP header/protocol string literals with named constants

### DIFF
--- a/internal/proxy/errors_proxy.go
+++ b/internal/proxy/errors_proxy.go
@@ -147,9 +147,9 @@ func writeHTTPError(conn net.Conn, pe *proxyError) {
 	body := pe.body()
 	// RFC 9209 Proxy-Status header with RFC 8941 Structured Fields syntax.
 	header := http.Header{
-		"Content-Type": {"text/plain; charset=utf-8"},
-		"Connection":   {"close"},
-		"Proxy-Status": {"spnego-proxy; error=" + pe.errorType},
+		headerContentType: {contentTypeTextUTF8},
+		headerConnection:  {connectionClose},
+		headerProxyStatus: {proxyStatusPrefix + pe.errorType},
 	}
 
 	resp := &http.Response{

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -31,7 +31,7 @@ func prepareForwardRequest(conn net.Conn, req *http.Request, cfg Config, clientA
 	// RFC 9110 §7.6.3: loop detection must run BEFORE sanitizeHopByHop so
 	// that a client sending "Connection: Via" cannot strip Via and bypass
 	// the check.
-	if prior := req.Header.Get("Via"); prior != "" && strings.Contains(prior, cfg.Pseudonym) {
+	if prior := req.Header.Get(headerVia); prior != "" && strings.Contains(prior, cfg.Pseudonym) {
 		slog.Warn("proxy loop detected", "via", prior, "pseudonym", cfg.Pseudonym, "client_addr", clientAddr, "method", req.Method, "host", req.Host)
 		return false, errProxyLoopDetected
 	}
@@ -51,7 +51,7 @@ func prepareForwardRequest(conn net.Conn, req *http.Request, cfg Config, clientA
 
 	// G1 (RFC 9110 §7.6.2): TRACE/OPTIONS Max-Forwards.
 	if req.Method == http.MethodTrace || req.Method == http.MethodOptions {
-		if mf := req.Header.Get("Max-Forwards"); mf != "" {
+		if mf := req.Header.Get(headerMaxForwards); mf != "" {
 			n, err := strconv.Atoi(mf)
 			switch {
 			case err != nil:
@@ -61,7 +61,7 @@ func prepareForwardRequest(conn net.Conn, req *http.Request, cfg Config, clientA
 				writeMaxForwardsResponse(conn, req)
 				return false, nil
 			default:
-				req.Header.Set("Max-Forwards", strconv.Itoa(n-1))
+				req.Header.Set(headerMaxForwards, strconv.Itoa(n-1))
 			}
 		}
 	}
@@ -98,7 +98,7 @@ func dialAndAuthUpstream(conn net.Conn, req *http.Request, cfg Config, clientAdd
 		writeHTTPError(conn, pe)
 		return nil
 	}
-	req.Header.Set("Proxy-Authorization", "Negotiate "+token)
+	req.Header.Set(headerProxyAuthorization, negotiateScheme+token)
 
 	proxyConn, derr := dialUpstream(cfg.Upstream, cfg.UpstreamTLS)
 	if derr != nil {
@@ -232,7 +232,7 @@ func handleClient(conn net.Conn, cfg Config) {
 		}
 		injectVia(req.Header, req.Proto, cfg.Pseudonym)
 
-		slog.Debug("proxy request", "method", req.Method, "uri", req.RequestURI, "proto", req.Proto, "headers", len(req.Header), "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "via", req.Header.Get("Via"), "iter", iter)
+		slog.Debug("proxy request", "method", req.Method, "uri", req.RequestURI, "proto", req.Proto, "headers", len(req.Header), "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "via", req.Header.Get(headerVia), "iter", iter)
 		if err := req.WriteProxy(proxyConn); err != nil {
 			slog.Error("failed to write request to proxy", "error", err, "error_type", errConnectionTerminated.errorType, "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "method", req.Method, "host", req.Host)
 			writeHTTPError(conn, errConnectionTerminated)
@@ -285,7 +285,7 @@ func forwardConnectViaUpstream(conn net.Conn, req *http.Request, reqReader *bufi
 	defer func() { _ = proxyConn.Close() }()
 	injectVia(req.Header, req.Proto, cfg.Pseudonym)
 
-	slog.Debug("proxy request", "method", req.Method, "uri", req.RequestURI, "proto", req.Proto, "headers", len(req.Header), "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "via", req.Header.Get("Via"))
+	slog.Debug("proxy request", "method", req.Method, "uri", req.RequestURI, "proto", req.Proto, "headers", len(req.Header), "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "via", req.Header.Get(headerVia))
 	if err := req.WriteProxy(proxyConn); err != nil {
 		slog.Error("failed to write request to proxy", "error", err, "error_type", errConnectionTerminated.errorType, "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "method", req.Method, "host", req.Host)
 		writeHTTPError(conn, errConnectionTerminated)

--- a/internal/proxy/headers.go
+++ b/internal/proxy/headers.go
@@ -54,21 +54,21 @@ func injectForwardingHeaders(req *http.Request, clientAddr string, fwdCfg Forwar
 	if fwdCfg.ForwardedEnabled {
 		obfID := generateObfuscatedID()
 		entry := fmt.Sprintf("for=%s;proto=http", obfID)
-		appendHeaderValue(req.Header, "Forwarded", entry)
+		appendHeaderValue(req.Header, headerForwarded, entry)
 	}
 
 	// H2/H3/H4
 	if fwdCfg.XForwardedForEnabled {
 		clientIP := extractHost(clientAddr)
 		// H2
-		appendHeaderValue(req.Header, "X-Forwarded-For", clientIP)
+		appendHeaderValue(req.Header, headerXForwardedFor, clientIP)
 		// H3
-		if req.Header.Get("X-Forwarded-Proto") == "" {
-			req.Header.Set("X-Forwarded-Proto", "http")
+		if req.Header.Get(headerXForwardedProto) == "" {
+			req.Header.Set(headerXForwardedProto, schemeHTTP)
 		}
 		// H4
-		if req.Header.Get("X-Forwarded-Host") == "" {
-			req.Header.Set("X-Forwarded-Host", req.Host)
+		if req.Header.Get(headerXForwardedHost) == "" {
+			req.Header.Set(headerXForwardedHost, req.Host)
 		}
 	}
 }
@@ -85,7 +85,7 @@ func GenerateViaPseudonym() string {
 // RFC 9110 §7.6.3. The entry identifies this proxy instance using the
 // protocol version received and the proxy's pseudonym.
 func injectVia(header http.Header, proto, pseudonym string) {
-	appendHeaderValue(header, "Via", proto+" "+pseudonym)
+	appendHeaderValue(header, headerVia, proto+" "+pseudonym)
 }
 
 // writeConnectOK writes a raw CONNECT 2xx response to conn without using
@@ -100,7 +100,7 @@ func writeConnectOK(conn net.Conn, resp *http.Response) error {
 	fmt.Fprintf(&buf, "HTTP/%d.%d %d %s\r\n",
 		resp.ProtoMajor, resp.ProtoMinor,
 		resp.StatusCode, http.StatusText(resp.StatusCode))
-	if via := resp.Header.Get("Via"); via != "" {
+	if via := resp.Header.Get(headerVia); via != "" {
 		fmt.Fprintf(&buf, "Via: %s\r\n", via)
 	}
 	buf.WriteString("\r\n")
@@ -125,34 +125,34 @@ func sanitizeHopByHop(req *http.Request) {
 
 	// B1 (RFC 9110 §7.6.1): parse the Connection header for additional
 	// field names to remove, then remove Connection itself.
-	for _, v := range header["Connection"] {
+	for _, v := range header[headerConnection] {
 		for name := range strings.SplitSeq(v, ",") {
 			if name = strings.TrimSpace(name); name != "" {
 				header.Del(name)
 			}
 		}
 	}
-	header.Del("Connection")
+	header.Del(headerConnection)
 
 	// Well-known hop-by-hop headers (RFC 9110 §7.6.1, RFC 9113 §8.2.2).
-	header.Del("Keep-Alive")
-	header.Del("Proxy-Connection") // K3: non-standard hop-by-hop
-	header.Del("TE")
-	header.Del("Trailer")
-	req.Trailer = nil     // ReadRequest moves Trailer into this field
-	header.Del("Upgrade") // J2: strip unless proxy supports the protocol
+	header.Del(headerKeepAlive)
+	header.Del(headerProxyConnection) // K3: non-standard hop-by-hop
+	header.Del(headerTE)
+	header.Del(headerTrailer)
+	req.Trailer = nil         // ReadRequest moves Trailer into this field
+	header.Del(headerUpgrade) // J2: strip unless proxy supports the protocol
 
 	// B2 (RFC 9110 §11.7.1): consume the client's Proxy-Authorization.
 	// The proxy injects its own SPNEGO token after this function returns.
-	header.Del("Proxy-Authorization")
+	header.Del(headerProxyAuthorization)
 
 	// E1 (RFC 9112 §6.1): when both Transfer-Encoding and Content-Length
 	// are present, remove Content-Length to prevent request smuggling.
 	// ReadRequest moves Transfer-Encoding into req.TransferEncoding, so
 	// we check that field rather than the header map.
-	if cl := header.Get("Content-Length"); len(req.TransferEncoding) > 0 && cl != "" {
+	if cl := header.Get(headerContentLength); len(req.TransferEncoding) > 0 && cl != "" {
 		logTECLConflict("request", req.TransferEncoding, cl)
-		header.Del("Content-Length")
+		header.Del(headerContentLength)
 	}
 }
 
@@ -173,14 +173,14 @@ func writeMaxForwardsResponse(conn net.Conn, req *http.Request) {
 		ProtoMajor: 1,
 		ProtoMinor: 1,
 		Header: http.Header{
-			"Content-Type": {"text/plain; charset=utf-8"},
-			"Connection":   {"close"},
+			headerContentType: {contentTypeTextUTF8},
+			headerConnection:  {connectionClose},
 		},
 		Body: http.NoBody,
 	}
 	// OPTIONS: advertise the request methods this proxy accepts.
 	if req.Method == http.MethodOptions {
-		resp.Header.Set("Allow", "GET, HEAD, POST, PUT, DELETE, OPTIONS, TRACE, CONNECT")
+		resp.Header.Set(headerAllow, allowMethods)
 	}
 	_ = resp.Write(conn)
 }

--- a/internal/proxy/headers_const.go
+++ b/internal/proxy/headers_const.go
@@ -1,0 +1,48 @@
+package proxy
+
+// HTTP header field names and protocol value literals used across the proxy.
+//
+// INVARIANT: every header-name constant MUST be in HTTP canonical form
+// (e.g. "Content-Length", not "content-length"). Several call sites read or
+// write the http.Header map directly — header[headerConnection],
+// resp.Header[headerContentLength], and http.Header{...} composite literals —
+// which bypass net/http's automatic canonicalisation. A non-canonical value
+// here would silently fail to match at those sites. Do not "normalise" these
+// strings.
+//
+// Every value below is byte-for-byte identical to the literal it replaced;
+// this catalogue is a pure refactor with no behaviour change.
+
+// HTTP header field names (RFC 9110 canonical form).
+const (
+	headerForwarded          = "Forwarded"         // RFC 7239
+	headerXForwardedFor      = "X-Forwarded-For"   // de facto
+	headerXForwardedProto    = "X-Forwarded-Proto" // de facto
+	headerXForwardedHost     = "X-Forwarded-Host"  // de facto
+	headerVia                = "Via"               // RFC 9110 §7.6.3
+	headerConnection         = "Connection"        // RFC 9110 §7.6.1
+	headerKeepAlive          = "Keep-Alive"
+	headerProxyConnection    = "Proxy-Connection" // non-standard hop-by-hop
+	headerTE                 = "TE"
+	headerTrailer            = "Trailer"
+	headerUpgrade            = "Upgrade"
+	headerProxyAuthorization = "Proxy-Authorization" // RFC 9110 §11.7.1
+	headerProxyAuthenticate  = "Proxy-Authenticate"  // RFC 9110 §11.7.2
+	headerContentLength      = "Content-Length"      // RFC 9112 §6.1
+	headerContentType        = "Content-Type"
+	headerAllow              = "Allow"        // RFC 9110 §10.2.1
+	headerMaxForwards        = "Max-Forwards" // RFC 9110 §7.6.2
+	headerProxyStatus        = "Proxy-Status" // RFC 9209
+)
+
+// Protocol value literals. Correctness-sensitive, not merely deduplication:
+// negotiateScheme carries a MANDATORY trailing space (RFC 4559 auth-scheme
+// followed by SP before the token).
+const (
+	negotiateScheme     = "Negotiate "                // RFC 4559; trailing SP REQUIRED — do not trim
+	connectionClose     = "close"                     // Connection header value
+	contentTypeTextUTF8 = "text/plain; charset=utf-8" // exact: single space after ';'
+	proxyStatusPrefix   = "spnego-proxy; error="      // RFC 9209 + RFC 8941; trailing '=' intentional
+	schemeHTTP          = "http"                      // X-Forwarded-Proto default
+	allowMethods        = "GET, HEAD, POST, PUT, DELETE, OPTIONS, TRACE, CONNECT"
+)

--- a/internal/proxy/response.go
+++ b/internal/proxy/response.go
@@ -100,7 +100,7 @@ func hasForbiddenFieldValueByte(v string) bool {
 // Content-Length values per RFC 9112 §6.1. It returns a non-nil *proxyError
 // when the response must be rejected with 502.
 func validateResponseContentLength(resp *http.Response) *proxyError {
-	clValues := resp.Header["Content-Length"]
+	clValues := resp.Header[headerContentLength]
 	if len(clValues) == 0 {
 		return nil
 	}
@@ -191,9 +191,9 @@ func readUpstreamResponse(upstreamReader *bufio.Reader, req *http.Request, pseud
 
 	// RFC 9112 §6.1: if both Transfer-Encoding and Content-Length
 	// are present in the response, remove Content-Length.
-	if cl := resp.Header.Get("Content-Length"); len(resp.TransferEncoding) > 0 && cl != "" {
+	if cl := resp.Header.Get(headerContentLength); len(resp.TransferEncoding) > 0 && cl != "" {
 		logTECLConflict("response", resp.TransferEncoding, cl)
-		resp.Header.Del("Content-Length")
+		resp.Header.Del(headerContentLength)
 		// Reset to -1 so resp.Write uses chunked framing instead
 		// of a fixed-length body derived from the removed header.
 		resp.ContentLength = -1
@@ -202,7 +202,7 @@ func readUpstreamResponse(upstreamReader *bufio.Reader, req *http.Request, pseud
 	// B3 (RFC 9110 §11.7.2): Proxy-Authenticate is hop-by-hop — it applies
 	// only between the client and the next inbound proxy. Strip it before
 	// relaying the response downstream.
-	resp.Header.Del("Proxy-Authenticate")
+	resp.Header.Del(headerProxyAuthenticate)
 
 	// RFC 9110 §7.6.3: a forward proxy MUST add Via to responses.
 	injectVia(resp.Header, resp.Proto, pseudonym)


### PR DESCRIPTION
## Context

`internal/proxy` repeated HTTP header-name string literals (`"Via"`, `"Connection"`, `"Proxy-Authorization"`, `"Content-Length"`, …) and protocol value literals across 4 production files with **zero** named constants. Risks:

- **Casing drift** — several sites use *raw map access* (`header["Connection"]`, `resp.Header["Content-Length"]`, `http.Header{...}` composite literals) which bypass `net/http` canonicalisation. A mis-cased literal there silently fails to match.
- **Invisible footgun** — `"Negotiate "` (forward.go) carries a mandatory trailing space (RFC 4559 auth-scheme + SP).
- **No single source of truth** — same strings duplicated across prod (and ~9 test files).

## Change

New `internal/proxy/headers_const.go` catalogues all header-name and protocol-value literals (unexported camelCase, matching the existing `errorType*` precedent in `errors_proxy.go`). Production call sites in `headers.go`, `forward.go`, `response.go`, `errors_proxy.go` now reference the constants.

**Pure refactor — net string equality preserved byte-for-byte. No behaviour change, no CLI-contract impact → no SemVer bump** (`refactor:` per CLAUDE.md).

Beyond dedup, this is a correctness safeguard: the raw-map-access invariant (canonical-form keys mandatory) is now explicit and centrally enforced.

### Intentionally untouched

- `sanitizeHopByHop` dynamic `header.Del(name)` — `name` is parsed from the Connection header *value* at runtime; no literal.
- `response.go` `strings.Contains(err.Error(), "Content-Length")` — substring match against Go stdlib's *error message text*, not a header operation; semantically distinct from the header-name constant.

### Deferred

Test-file literal sweep (`"Via"` ~52×, `"Proxy-Status"` ~28×, …) → separate follow-up `refactor:` commit, to keep this correctness-sensitive prod diff reviewable.

## Verification

- `gofmt -l internal/proxy/` — clean
- `go build ./...` — pass
- `go vet ./...` — pass
- `go test -count=1 ./...` — 476 passed
- string-set proof: zero bare header-op literals remain in the 4 edited files

🤖 Generated with [Claude Code](https://claude.com/claude-code)