### PR TITLE
refactor: replace HTTP header-name string literals with named constants in tests

### DIFF
--- a/internal/proxy/connect_test.go
+++ b/internal/proxy/connect_test.go
@@ -121,7 +121,7 @@ func TestD4_ConnectPortRestriction(t *testing.T) {
 
 			if tc.wantStatus == http.StatusForbidden {
 				wantPS := "spnego-proxy; error=http_request_denied"
-				if got := resp.Header.Get("Proxy-Status"); got != wantPS {
+				if got := resp.Header.Get(headerProxyStatus); got != wantPS {
 					t.Errorf("Proxy-Status: want %q, got %q", wantPS, got)
 				}
 
@@ -572,8 +572,8 @@ func TestD3_RFC9112_NoTransferEncodingInCONNECTResponse(t *testing.T) {
 	// Content-Length and Connection: close MUST NOT appear in the CONNECT
 	// 2xx response — they cause Bun/undici to close the connection before
 	// the TLS handshake through the tunnel can begin.
-	assertHeaderAbsent(t, resp.Header, "Content-Length")
-	assertHeaderAbsent(t, resp.Header, "Connection")
+	assertHeaderAbsent(t, resp.Header, headerContentLength)
+	assertHeaderAbsent(t, resp.Header, headerConnection)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/proxy/forwarding_fidelity_test.go
+++ b/internal/proxy/forwarding_fidelity_test.go
@@ -235,8 +235,8 @@ func TestForwardingC7_NoTransformBodyPreserved(t *testing.T) {
 			ProtoMajor: 1,
 			ProtoMinor: 1,
 			Header: http.Header{
-				"Cache-Control": {"no-transform"},
-				"Content-Type":  {"application/octet-stream"},
+				"Cache-Control":   {"no-transform"},
+				headerContentType: {"application/octet-stream"},
 			},
 			Body:          io.NopCloser(strings.NewReader(body)),
 			ContentLength: int64(len(body)),
@@ -296,7 +296,7 @@ func TestForwardingB3_ProxyAuthenticateNotForwardedToClient(t *testing.T) {
 			ProtoMajor: 1,
 			ProtoMinor: 1,
 			Header: http.Header{
-				"Proxy-Authenticate": {"Negotiate"},
+				headerProxyAuthenticate: {"Negotiate"},
 			},
 			Body:          http.NoBody,
 			ContentLength: 0,
@@ -312,5 +312,5 @@ func TestForwardingB3_ProxyAuthenticateNotForwardedToClient(t *testing.T) {
 	assertStatusCode(t, resp, http.StatusOK)
 
 	// B3: Proxy-Authenticate MUST NOT be forwarded to the client.
-	assertHeaderAbsent(t, resp.Header, "Proxy-Authenticate")
+	assertHeaderAbsent(t, resp.Header, headerProxyAuthenticate)
 }

--- a/internal/proxy/forwarding_headers_test.go
+++ b/internal/proxy/forwarding_headers_test.go
@@ -24,7 +24,7 @@ func withForwardingConfig(cfg ForwardingConfig) func(*ProxyUnderTest) {
 // added when ForwardingConfig.ForwardedEnabled is false (the zero value).
 func TestForwardedDisabledByDefault(t *testing.T) {
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(ForwardingConfig{}))
-	assertHeaderAbsent(t, rec.Header, "Forwarded")
+	assertHeaderAbsent(t, rec.Header, headerForwarded)
 }
 
 // TestForwardedHeaderAdded verifies that when ForwardedEnabled is true the
@@ -33,7 +33,7 @@ func TestForwardedDisabledByDefault(t *testing.T) {
 func TestForwardedHeaderAdded(t *testing.T) {
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(ForwardingConfig{ForwardedEnabled: true}))
 
-	fwd := rec.Header.Get("Forwarded")
+	fwd := rec.Header.Get(headerForwarded)
 	if fwd == "" {
 		t.Fatal("expected Forwarded header, got none")
 	}
@@ -53,11 +53,11 @@ func TestForwardedHeaderAdded(t *testing.T) {
 func TestForwardedChaining(t *testing.T) {
 	existing := "for=192.0.2.60;proto=http;by=203.0.113.43"
 	rec := proxyRoundTrip(t,
-		http.Header{"Forwarded": {existing}},
+		http.Header{headerForwarded: {existing}},
 		withForwardingConfig(ForwardingConfig{ForwardedEnabled: true}),
 	)
 
-	fwd := rec.Header.Get("Forwarded")
+	fwd := rec.Header.Get(headerForwarded)
 	if fwd == "" {
 		t.Fatal("expected Forwarded header, got none")
 	}
@@ -110,7 +110,7 @@ func TestForwardedObfuscatedFormat(t *testing.T) {
 // added when ForwardingConfig.XForwardedForEnabled is false (the zero value).
 func TestXForwardedForDisabledByDefault(t *testing.T) {
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(ForwardingConfig{}))
-	assertHeaderAbsent(t, rec.Header, "X-Forwarded-For")
+	assertHeaderAbsent(t, rec.Header, headerXForwardedFor)
 }
 
 // TestXForwardedForAdded verifies that when XForwardedForEnabled is true, the
@@ -118,7 +118,7 @@ func TestXForwardedForDisabledByDefault(t *testing.T) {
 func TestXForwardedForAdded(t *testing.T) {
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(ForwardingConfig{XForwardedForEnabled: true}))
 
-	xff := rec.Header.Get("X-Forwarded-For")
+	xff := rec.Header.Get(headerXForwardedFor)
 	if xff == "" {
 		t.Fatal("expected X-Forwarded-For header, got none")
 	}
@@ -133,11 +133,11 @@ func TestXForwardedForAdded(t *testing.T) {
 func TestXForwardedForChaining(t *testing.T) {
 	existing := "10.0.0.1"
 	rec := proxyRoundTrip(t,
-		http.Header{"X-Forwarded-For": {existing}},
+		http.Header{headerXForwardedFor: {existing}},
 		withForwardingConfig(ForwardingConfig{XForwardedForEnabled: true}),
 	)
 
-	xff := rec.Header.Get("X-Forwarded-For")
+	xff := rec.Header.Get(headerXForwardedFor)
 	if !strings.HasPrefix(xff, existing) {
 		t.Errorf("X-Forwarded-For %q: expected to start with existing value %q", xff, existing)
 	}
@@ -155,7 +155,7 @@ func TestXForwardedForChaining(t *testing.T) {
 func TestXForwardedProtoAddedWithXFF(t *testing.T) {
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(ForwardingConfig{XForwardedForEnabled: true}))
 
-	if got := rec.Header.Get("X-Forwarded-Proto"); got != "http" {
+	if got := rec.Header.Get(headerXForwardedProto); got != "http" {
 		t.Errorf("X-Forwarded-Proto: want %q, got %q", "http", got)
 	}
 }
@@ -164,11 +164,11 @@ func TestXForwardedProtoAddedWithXFF(t *testing.T) {
 // X-Forwarded-Proto value is not replaced.
 func TestXForwardedProtoNotOverwritten(t *testing.T) {
 	rec := proxyRoundTrip(t,
-		http.Header{"X-Forwarded-Proto": {"https"}},
+		http.Header{headerXForwardedProto: {"https"}},
 		withForwardingConfig(ForwardingConfig{XForwardedForEnabled: true}),
 	)
 
-	if got := rec.Header.Get("X-Forwarded-Proto"); got != "https" {
+	if got := rec.Header.Get(headerXForwardedProto); got != "https" {
 		t.Errorf("X-Forwarded-Proto: want existing %q preserved, got %q", "https", got)
 	}
 }
@@ -177,7 +177,7 @@ func TestXForwardedProtoNotOverwritten(t *testing.T) {
 // not injected when XForwardedForEnabled is false.
 func TestXForwardedProtoAbsentWhenDisabled(t *testing.T) {
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(ForwardingConfig{}))
-	assertHeaderAbsent(t, rec.Header, "X-Forwarded-Proto")
+	assertHeaderAbsent(t, rec.Header, headerXForwardedProto)
 }
 
 // ---------------------------------------------------------------------------
@@ -189,7 +189,7 @@ func TestXForwardedProtoAbsentWhenDisabled(t *testing.T) {
 func TestXForwardedHostAddedWithXFF(t *testing.T) {
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(ForwardingConfig{XForwardedForEnabled: true}))
 
-	if got := rec.Header.Get("X-Forwarded-Host"); got != "example.com" {
+	if got := rec.Header.Get(headerXForwardedHost); got != "example.com" {
 		t.Errorf("X-Forwarded-Host: want %q, got %q", "example.com", got)
 	}
 }
@@ -198,11 +198,11 @@ func TestXForwardedHostAddedWithXFF(t *testing.T) {
 // X-Forwarded-Host value is not replaced.
 func TestXForwardedHostNotOverwritten(t *testing.T) {
 	rec := proxyRoundTrip(t,
-		http.Header{"X-Forwarded-Host": {"original.example.com"}},
+		http.Header{headerXForwardedHost: {"original.example.com"}},
 		withForwardingConfig(ForwardingConfig{XForwardedForEnabled: true}),
 	)
 
-	if got := rec.Header.Get("X-Forwarded-Host"); got != "original.example.com" {
+	if got := rec.Header.Get(headerXForwardedHost); got != "original.example.com" {
 		t.Errorf("X-Forwarded-Host: want existing %q preserved, got %q", "original.example.com", got)
 	}
 }
@@ -211,7 +211,7 @@ func TestXForwardedHostNotOverwritten(t *testing.T) {
 // injected when XForwardedForEnabled is false.
 func TestXForwardedHostAbsentWhenDisabled(t *testing.T) {
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(ForwardingConfig{}))
-	assertHeaderAbsent(t, rec.Header, "X-Forwarded-Host")
+	assertHeaderAbsent(t, rec.Header, headerXForwardedHost)
 }
 
 // ---------------------------------------------------------------------------
@@ -227,16 +227,16 @@ func TestBothForwardingHeadersEnabled(t *testing.T) {
 	}
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(cfg))
 
-	if fwd := rec.Header.Get("Forwarded"); fwd == "" {
+	if fwd := rec.Header.Get(headerForwarded); fwd == "" {
 		t.Error("expected Forwarded header, got none")
 	}
-	if xff := rec.Header.Get("X-Forwarded-For"); xff == "" {
+	if xff := rec.Header.Get(headerXForwardedFor); xff == "" {
 		t.Error("expected X-Forwarded-For header, got none")
 	}
-	if xfp := rec.Header.Get("X-Forwarded-Proto"); xfp != "http" {
+	if xfp := rec.Header.Get(headerXForwardedProto); xfp != "http" {
 		t.Errorf("X-Forwarded-Proto: want %q, got %q", "http", xfp)
 	}
-	if xfh := rec.Header.Get("X-Forwarded-Host"); xfh != "example.com" {
+	if xfh := rec.Header.Get(headerXForwardedHost); xfh != "example.com" {
 		t.Errorf("X-Forwarded-Host: want %q, got %q", "example.com", xfh)
 	}
 }
@@ -271,7 +271,7 @@ func TestForwardingHeadersDoNotAffectVia(t *testing.T) {
 	}
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(cfg))
 
-	via := rec.Header.Get("Via")
+	via := rec.Header.Get(headerVia)
 	if via == "" {
 		t.Error("Via header absent when forwarding headers enabled")
 	}
@@ -290,5 +290,5 @@ func TestForwardingHeadersDoNotAffectProxyAuthorization(t *testing.T) {
 	}
 	rec := proxyRoundTrip(t, nil, withForwardingConfig(cfg))
 
-	assertHeaderPresent(t, rec.Header, "Proxy-Authorization", fmt.Sprintf("Negotiate %s", "test-token"))
+	assertHeaderPresent(t, rec.Header, headerProxyAuthorization, fmt.Sprintf("Negotiate %s", "test-token"))
 }

--- a/internal/proxy/framing_conformance_test.go
+++ b/internal/proxy/framing_conformance_test.go
@@ -47,7 +47,7 @@ func TestE3_RFC9112_NonChunkedTransferEncoding_Request(t *testing.T) {
 			if resp.StatusCode != http.StatusBadRequest && resp.StatusCode != http.StatusBadGateway {
 				t.Errorf("status: want 400 or 502, got %d", resp.StatusCode)
 			}
-			if ps := resp.Header.Get("Proxy-Status"); !strings.Contains(ps, "http_") {
+			if ps := resp.Header.Get(headerProxyStatus); !strings.Contains(ps, "http_") {
 				t.Errorf("expected http_* Proxy-Status token, got %q", ps)
 			}
 			if len(reqs) != 0 {
@@ -141,7 +141,7 @@ func TestE5_RFC9110_ResponseHeaderControlOctetsRejected(t *testing.T) {
 			defer func() { _ = resp.Body.Close() }()
 
 			assertStatusCode(t, resp, http.StatusBadGateway)
-			if ps := resp.Header.Get("Proxy-Status"); !strings.Contains(ps, "http_protocol_error") {
+			if ps := resp.Header.Get(headerProxyStatus); !strings.Contains(ps, "http_protocol_error") {
 				t.Errorf("expected Proxy-Status to contain 'http_protocol_error', got %q", ps)
 			}
 			// The injected header MUST NOT reach the client.
@@ -296,7 +296,7 @@ func TestE7_RFC9112_ChunkedResponseWithTrailerConsistent(t *testing.T) {
 	// value must arrive (resp.Trailer populated) OR Trailer must be
 	// stripped from the response headers. The proxy must not advertise
 	// trailers it will never deliver.
-	advertised := resp.Header.Get("Trailer")
+	advertised := resp.Header.Get(headerTrailer)
 	if advertised != "" {
 		// Trailer advertised → the named trailer must be present.
 		if v := resp.Trailer.Get(advertised); v == "" {

--- a/internal/proxy/gokrb5_integration_test.go
+++ b/internal/proxy/gokrb5_integration_test.go
@@ -118,8 +118,8 @@ func TestProxyChainWithRealToken(t *testing.T) {
 			return
 		}
 		_ = req.Body.Close()
-		gotAuth <- req.Header.Get("Proxy-Authorization")
-		gotVia <- req.Header.Get("Via")
+		gotAuth <- req.Header.Get(headerProxyAuthorization)
+		gotVia <- req.Header.Get(headerVia)
 
 		resp := "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
 		_, _ = conn.Write([]byte(resp))

--- a/internal/proxy/harness_test.go
+++ b/internal/proxy/harness_test.go
@@ -546,7 +546,7 @@ func TestComplianceHarnessSmokeTest(t *testing.T) {
 	assertHeaderPresent(t, resp.Header, "X-Upstream", "true")
 
 	// Via header must be present on the response per RFC 9110 §7.6.3.
-	if via := resp.Header.Get("Via"); via == "" {
+	if via := resp.Header.Get(headerVia); via == "" {
 		t.Error("expected Via header in response, got empty")
 	} else if !strings.Contains(via, testPseudonym) {
 		t.Errorf("Via header %q does not contain pseudonym %q", via, testPseudonym)
@@ -568,13 +568,13 @@ func TestComplianceHarnessSmokeTest(t *testing.T) {
 	upstreamReq := reqs[0]
 
 	// Proxy-Authorization must be injected by the proxy.
-	assertHeaderPresent(t, upstreamReq.Header, "Proxy-Authorization", "Negotiate test-token")
+	assertHeaderPresent(t, upstreamReq.Header, headerProxyAuthorization, "Negotiate test-token")
 
 	// Custom header must be forwarded transparently.
 	assertHeaderPresent(t, upstreamReq.Header, "X-Custom", "value")
 
 	// Via must be present on the forwarded request.
-	if via := upstreamReq.Header.Get("Via"); via == "" {
+	if via := upstreamReq.Header.Get(headerVia); via == "" {
 		t.Error("expected Via header in upstream request, got empty")
 	}
 

--- a/internal/proxy/hop_by_hop_test.go
+++ b/internal/proxy/hop_by_hop_test.go
@@ -18,25 +18,25 @@ import (
 
 func TestB1_RFC9110_ConnectionHeaderAndNamedHeadersRemoved(t *testing.T) {
 	upReq := proxyRoundTrip(t, http.Header{
-		"Connection":   {"X-Custom-Hop"},
-		"X-Custom-Hop": {"secret"},
-		"X-Legitimate": {"keep-me"},
+		headerConnection: {"X-Custom-Hop"},
+		"X-Custom-Hop":   {"secret"},
+		"X-Legitimate":   {"keep-me"},
 	})
 
-	assertHeaderAbsent(t, upReq.Header, "Connection")
+	assertHeaderAbsent(t, upReq.Header, headerConnection)
 	assertHeaderAbsent(t, upReq.Header, "X-Custom-Hop")
 	assertHeaderPresent(t, upReq.Header, "X-Legitimate", "keep-me")
 }
 
 func TestB1_RFC9110_ConnectionHeaderMultipleValues(t *testing.T) {
 	upReq := proxyRoundTrip(t, http.Header{
-		"Connection":   {"X-Hop-A, X-Hop-B"},
-		"X-Hop-A":      {"a-value"},
-		"X-Hop-B":      {"b-value"},
-		"X-End-To-End": {"preserved"},
+		headerConnection: {"X-Hop-A, X-Hop-B"},
+		"X-Hop-A":        {"a-value"},
+		"X-Hop-B":        {"b-value"},
+		"X-End-To-End":   {"preserved"},
 	})
 
-	assertHeaderAbsent(t, upReq.Header, "Connection")
+	assertHeaderAbsent(t, upReq.Header, headerConnection)
 	assertHeaderAbsent(t, upReq.Header, "X-Hop-A")
 	assertHeaderAbsent(t, upReq.Header, "X-Hop-B")
 	assertHeaderPresent(t, upReq.Header, "X-End-To-End", "preserved")
@@ -52,11 +52,11 @@ func TestHopByHop_WellKnownHeadersStripped(t *testing.T) {
 		header string
 		value  string
 	}{
-		{"B1/Keep-Alive", "Keep-Alive", "timeout=5"},
-		{"K3/Proxy-Connection", "Proxy-Connection", "keep-alive"},
-		{"J2/Upgrade", "Upgrade", "websocket"},
-		{"B1/TE", "TE", "trailers"},
-		{"B1/Trailer", "Trailer", "X-Checksum"},
+		{"B1/Keep-Alive", headerKeepAlive, "timeout=5"},
+		{"K3/Proxy-Connection", headerProxyConnection, "keep-alive"},
+		{"J2/Upgrade", headerUpgrade, "websocket"},
+		{"B1/TE", headerTE, "trailers"},
+		{"B1/Trailer", headerTrailer, "X-Checksum"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -72,12 +72,12 @@ func TestHopByHop_WellKnownHeadersStripped(t *testing.T) {
 
 func TestB2_RFC9110_ClientProxyAuthorizationConsumed(t *testing.T) {
 	upReq := proxyRoundTrip(t, http.Header{
-		"Proxy-Authorization": {"Basic abc123"},
+		headerProxyAuthorization: {"Basic abc123"},
 	})
 
 	// The proxy must inject its own Negotiate token, NOT forward the
 	// client's Basic credential.
-	pa := upReq.Header.Get("Proxy-Authorization")
+	pa := upReq.Header.Get(headerProxyAuthorization)
 	if pa == "Basic abc123" {
 		t.Error("client's Proxy-Authorization was forwarded; expected proxy's own Negotiate token")
 	}
@@ -129,7 +129,7 @@ func TestE1_RFC9112_TEAndCLConflictRemovesCL(t *testing.T) {
 	}
 
 	// Content-Length must be absent.
-	assertHeaderAbsent(t, reqs[0].Header, "Content-Length")
+	assertHeaderAbsent(t, reqs[0].Header, headerContentLength)
 
 	// Transfer-Encoding (chunked framing) must still be present so the
 	// upstream can correctly decode the body.
@@ -190,7 +190,7 @@ func TestE2_RFC9112_InvalidContentLengthInResponse(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	assertStatusCode(t, resp, http.StatusBadGateway)
-	if ps := resp.Header.Get("Proxy-Status"); !strings.Contains(ps, "http_protocol_error") {
+	if ps := resp.Header.Get(headerProxyStatus); !strings.Contains(ps, "http_protocol_error") {
 		t.Errorf("expected Proxy-Status to contain 'http_protocol_error', got %q", ps)
 	}
 }
@@ -295,7 +295,7 @@ func TestE1_RFC9112_ResponseTEAndCLConflictRemovesCL(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	assertStatusCode(t, resp, http.StatusOK)
-	assertHeaderAbsent(t, resp.Header, "Content-Length")
+	assertHeaderAbsent(t, resp.Header, headerContentLength)
 
 	body, _ := io.ReadAll(resp.Body)
 	if string(body) != "hello" {
@@ -318,68 +318,68 @@ func TestSanitizeHopByHop_Unit(t *testing.T) {
 		{
 			name: "B1: Connection names single header",
 			headers: http.Header{
-				"Connection":   {"X-Hop"},
-				"X-Hop":        {"val"},
-				"X-Persistent": {"val"},
+				headerConnection: {"X-Hop"},
+				"X-Hop":          {"val"},
+				"X-Persistent":   {"val"},
 			},
-			wantAbsent: []string{"Connection", "X-Hop"},
+			wantAbsent: []string{headerConnection, "X-Hop"},
 			wantKeep:   map[string]string{"X-Persistent": "val"},
 		},
 		{
 			name: "B1: Connection names multiple comma-separated headers",
 			headers: http.Header{
-				"Connection": {"X-A, X-B"},
-				"X-A":        {"a"},
-				"X-B":        {"b"},
+				headerConnection: {"X-A, X-B"},
+				"X-A":            {"a"},
+				"X-B":            {"b"},
 			},
-			wantAbsent: []string{"Connection", "X-A", "X-B"},
+			wantAbsent: []string{headerConnection, "X-A", "X-B"},
 		},
 		{
 			name: "B2: Proxy-Authorization removed",
 			headers: http.Header{
-				"Proxy-Authorization": {"Basic abc"},
+				headerProxyAuthorization: {"Basic abc"},
 			},
-			wantAbsent: []string{"Proxy-Authorization"},
+			wantAbsent: []string{headerProxyAuthorization},
 		},
 		{
 			name: "K3: Proxy-Connection removed",
 			headers: http.Header{
-				"Proxy-Connection": {"keep-alive"},
+				headerProxyConnection: {"keep-alive"},
 			},
-			wantAbsent: []string{"Proxy-Connection"},
+			wantAbsent: []string{headerProxyConnection},
 		},
 		{
 			name: "J2: Upgrade removed",
 			headers: http.Header{
-				"Upgrade": {"websocket"},
+				headerUpgrade: {"websocket"},
 			},
-			wantAbsent: []string{"Upgrade"},
+			wantAbsent: []string{headerUpgrade},
 		},
 		{
 			name: "Well-known hop-by-hop: Keep-Alive, TE, Trailer",
 			headers: http.Header{
-				"Keep-Alive": {"timeout=5"},
-				"Te":         {"trailers"},
-				"Trailer":    {"X-Checksum"},
+				headerKeepAlive: {"timeout=5"},
+				"Te":            {"trailers"},
+				headerTrailer:   {"X-Checksum"},
 			},
-			wantAbsent: []string{"Keep-Alive", "Te", "Trailer"},
+			wantAbsent: []string{headerKeepAlive, "Te", headerTrailer},
 		},
 		{
 			name:             "E1: TE + CL conflict removes CL",
-			headers:          http.Header{"Content-Length": {"100"}},
+			headers:          http.Header{headerContentLength: {"100"}},
 			transferEncoding: []string{"chunked"},
-			wantAbsent:       []string{"Content-Length"},
+			wantAbsent:       []string{headerContentLength},
 		},
 		{
 			name:     "E1: CL without TE is preserved",
-			headers:  http.Header{"Content-Length": {"42"}},
-			wantKeep: map[string]string{"Content-Length": "42"},
+			headers:  http.Header{headerContentLength: {"42"}},
+			wantKeep: map[string]string{headerContentLength: "42"},
 		},
 		{
 			name:    "empty Connection header",
-			headers: http.Header{"Connection": {""}},
+			headers: http.Header{headerConnection: {""}},
 			// Connection itself is removed; no crash on empty values.
-			wantAbsent: []string{"Connection"},
+			wantAbsent: []string{headerConnection},
 		},
 		{
 			name: "Connection names Proxy-Authorization",
@@ -387,10 +387,10 @@ func TestSanitizeHopByHop_Unit(t *testing.T) {
 			// Proxy-Authorization by naming it in Connection. This is
 			// safe because sanitizeHopByHop runs before token injection.
 			headers: http.Header{
-				"Connection":          {"Proxy-Authorization"},
-				"Proxy-Authorization": {"Basic attacker"},
+				headerConnection:         {"Proxy-Authorization"},
+				headerProxyAuthorization: {"Basic attacker"},
 			},
-			wantAbsent: []string{"Connection", "Proxy-Authorization"},
+			wantAbsent: []string{headerConnection, headerProxyAuthorization},
 		},
 	}
 
@@ -445,7 +445,7 @@ func TestValidateResponseContentLength_Unit(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			resp := &http.Response{Header: http.Header{}}
 			for _, v := range tc.cl {
-				resp.Header.Add("Content-Length", v)
+				resp.Header.Add(headerContentLength, v)
 			}
 			pe := validateResponseContentLength(resp)
 			if tc.wantErr && pe == nil {
@@ -464,17 +464,17 @@ func TestValidateResponseContentLength_Unit(t *testing.T) {
 
 func TestHopByHop_EndToEndHeadersPreserved(t *testing.T) {
 	upReq := proxyRoundTrip(t, http.Header{
-		"Accept":        {"text/html"},
-		"Authorization": {"Bearer token123"},
-		"Cache-Control": {"no-cache"},
-		"Content-Type":  {"application/json"},
-		"X-Custom-App":  {"my-value"},
+		"Accept":          {"text/html"},
+		"Authorization":   {"Bearer token123"},
+		"Cache-Control":   {"no-cache"},
+		headerContentType: {"application/json"},
+		"X-Custom-App":    {"my-value"},
 	})
 
 	assertHeaderPresent(t, upReq.Header, "Accept", "text/html")
 	assertHeaderPresent(t, upReq.Header, "Authorization", "Bearer token123")
 	assertHeaderPresent(t, upReq.Header, "Cache-Control", "no-cache")
-	assertHeaderPresent(t, upReq.Header, "Content-Type", "application/json")
+	assertHeaderPresent(t, upReq.Header, headerContentType, "application/json")
 	assertHeaderPresent(t, upReq.Header, "X-Custom-App", "my-value")
 }
 
@@ -486,7 +486,7 @@ func TestE2_RFC9112_MultipleDifferingCLInResponse(t *testing.T) {
 	// Go's http.ReadResponse rejects responses with differing
 	// Content-Length headers before our validateResponseContentLength
 	// runs. This test verifies the proxy returns 502 (via the
-	// strings.Contains "Content-Length" check in the ReadResponse
+	// strings.Contains headerContentLength check in the ReadResponse
 	// error path) rather than silently raw-relaying the smuggling
 	// attempt.
 	rawUpstream, err := net.Listen("tcp", "127.0.0.1:0")
@@ -535,7 +535,7 @@ func TestE2_RFC9112_MultipleDifferingCLInResponse(t *testing.T) {
 	defer func() { _ = resp.Body.Close() }()
 
 	assertStatusCode(t, resp, http.StatusBadGateway)
-	if ps := resp.Header.Get("Proxy-Status"); !strings.Contains(ps, "http_protocol_error") {
+	if ps := resp.Header.Get(headerProxyStatus); !strings.Contains(ps, "http_protocol_error") {
 		t.Errorf("expected Proxy-Status to contain 'http_protocol_error', got %q", ps)
 	}
 }
@@ -558,8 +558,8 @@ func TestHopByHop_ViaHeaderStillInjected(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 
 	req, _ := http.NewRequest("GET", "http://example.com/via", nil)
-	req.Header.Set("Connection", "close")
-	req.Header.Set("Proxy-Connection", "keep-alive")
+	req.Header.Set(headerConnection, "close")
+	req.Header.Set(headerProxyConnection, "keep-alive")
 	if err := req.WriteProxy(conn); err != nil {
 		t.Fatalf("write request: %v", err)
 	}
@@ -577,7 +577,7 @@ func TestHopByHop_ViaHeaderStillInjected(t *testing.T) {
 	}
 
 	// Via must be present on the forwarded request.
-	via := reqs[0].Header.Get("Via")
+	via := reqs[0].Header.Get(headerVia)
 	if via == "" {
 		t.Error("expected Via header in upstream request, got empty")
 	}
@@ -586,7 +586,7 @@ func TestHopByHop_ViaHeaderStillInjected(t *testing.T) {
 	}
 
 	// Via must also be present on the response.
-	if resp.Header.Get("Via") == "" {
+	if resp.Header.Get(headerVia) == "" {
 		t.Error("expected Via header in response, got empty")
 	}
 }
@@ -610,7 +610,7 @@ func TestHopByHop_ProxyAuthInjectedAfterSanitization(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 
 	req, _ := http.NewRequest("GET", "http://example.com/auth-inject", nil)
-	req.Header.Set("Proxy-Authorization", "Basic should-be-removed")
+	req.Header.Set(headerProxyAuthorization, "Basic should-be-removed")
 	if err := req.WriteProxy(conn); err != nil {
 		t.Fatalf("write request: %v", err)
 	}
@@ -627,7 +627,7 @@ func TestHopByHop_ProxyAuthInjectedAfterSanitization(t *testing.T) {
 		t.Fatalf("upstream received %d requests, want 1", len(reqs))
 	}
 
-	assertHeaderPresent(t, reqs[0].Header, "Proxy-Authorization",
+	assertHeaderPresent(t, reqs[0].Header, headerProxyAuthorization,
 		"Negotiate "+proxy.Provider.token)
 }
 
@@ -652,8 +652,8 @@ func TestHopByHop_ConnectionViaCannotBypassLoopDetection(t *testing.T) {
 	defer func() { _ = conn.Close() }()
 
 	req, _ := http.NewRequest("GET", "http://example.com/loop-bypass", nil)
-	req.Header.Set("Via", "1.1 "+testPseudonym)
-	req.Header.Set("Connection", "Via")
+	req.Header.Set(headerVia, "1.1 "+testPseudonym)
+	req.Header.Set(headerConnection, "Via")
 	if err := req.WriteProxy(conn); err != nil {
 		t.Fatalf("write request: %v", err)
 	}
@@ -667,7 +667,7 @@ func TestHopByHop_ConnectionViaCannotBypassLoopDetection(t *testing.T) {
 	// The proxy must return 502 with proxy_loop_detected, not forward
 	// the request with the Via header stripped.
 	assertStatusCode(t, resp, http.StatusBadGateway)
-	if ps := resp.Header.Get("Proxy-Status"); !strings.Contains(ps, "proxy_loop_detected") {
+	if ps := resp.Header.Get(headerProxyStatus); !strings.Contains(ps, "proxy_loop_detected") {
 		t.Errorf("expected Proxy-Status to contain 'proxy_loop_detected', got %q", ps)
 	}
 }
@@ -682,7 +682,7 @@ func TestHopByHop_ConnectionViaCannotBypassLoopDetection(t *testing.T) {
 func TestA1_RFC9110_ViaAppendedOnForwardedRequest(t *testing.T) {
 	upReq := proxyRoundTrip(t, nil)
 
-	via := upReq.Header.Get("Via")
+	via := upReq.Header.Get(headerVia)
 	want := "HTTP/1.1 " + testPseudonym
 	if via != want {
 		t.Errorf("Via header: want %q, got %q", want, via)
@@ -693,10 +693,10 @@ func TestA1_RFC9110_ViaAppendedOnForwardedRequest(t *testing.T) {
 // entries from upstream proxies are preserved and our entry is appended.
 func TestA1_RFC9110_ViaPreservesExistingEntries(t *testing.T) {
 	upReq := proxyRoundTrip(t, http.Header{
-		"Via": {"1.1 other-proxy"},
+		headerVia: {"1.1 other-proxy"},
 	})
 
-	via := upReq.Header.Get("Via")
+	via := upReq.Header.Get(headerVia)
 	want := "1.1 other-proxy, HTTP/1.1 " + testPseudonym
 	if via != want {
 		t.Errorf("Via header: want %q, got %q", want, via)
@@ -731,7 +731,7 @@ func TestA1_RFC9110_ViaAppendedOnResponse(t *testing.T) {
 
 	assertStatusCode(t, resp, http.StatusOK)
 
-	via := resp.Header.Get("Via")
+	via := resp.Header.Get(headerVia)
 	want := "HTTP/1.1 " + testPseudonym
 	if via != want {
 		t.Errorf("response Via header: want %q, got %q", want, via)
@@ -759,7 +759,7 @@ func loopDetectionScenario(t *testing.T) (*http.Response, *ProxyUnderTest, *Mock
 	t.Cleanup(func() { _ = conn.Close() })
 
 	req, _ := http.NewRequest("GET", "http://example.com/loop-test", nil)
-	req.Header.Set("Via", "1.1 "+testPseudonym)
+	req.Header.Set(headerVia, "1.1 "+testPseudonym)
 	if err := req.WriteProxy(conn); err != nil {
 		t.Fatalf("write request: %v", err)
 	}
@@ -783,7 +783,7 @@ func TestA2_RFC9110_LoopDetectionReturns502(t *testing.T) {
 	assertStatusCode(t, resp, http.StatusBadGateway)
 
 	wantPS := "spnego-proxy; error=proxy_loop_detected"
-	if ps := resp.Header.Get("Proxy-Status"); ps != wantPS {
+	if ps := resp.Header.Get(headerProxyStatus); ps != wantPS {
 		t.Errorf("Proxy-Status: want %q, got %q", wantPS, ps)
 	}
 
@@ -835,10 +835,10 @@ func TestA3_RFC9209_ProxyStatusOnLoopDetected(t *testing.T) {
 // detection — only this instance's own pseudonym indicates a loop.
 func TestA2_RFC9110_DifferentPseudonymNotDetectedAsLoop(t *testing.T) {
 	upReq := proxyRoundTrip(t, http.Header{
-		"Via": {"1.1 some-other-proxy"},
+		headerVia: {"1.1 some-other-proxy"},
 	})
 
-	via := upReq.Header.Get("Via")
+	via := upReq.Header.Get(headerVia)
 	want := "1.1 some-other-proxy, HTTP/1.1 " + testPseudonym
 	if via != want {
 		t.Errorf("Via header: want %q, got %q", want, via)
@@ -865,7 +865,7 @@ func TestA2_RFC9110_SubstringPseudonymDetectedAsLoop(t *testing.T) {
 
 	// Via entry contains our pseudonym as a prefix of a longer identifier.
 	req, _ := http.NewRequest("GET", "http://example.com/a2-substr", nil)
-	req.Header.Set("Via", "1.1 "+testPseudonym+"-extended")
+	req.Header.Set(headerVia, "1.1 "+testPseudonym+"-extended")
 	if err := req.WriteProxy(conn); err != nil {
 		t.Fatalf("write request: %v", err)
 	}
@@ -892,17 +892,17 @@ func TestInjectVia_EmptyHeader(t *testing.T) {
 	h := make(http.Header)
 	injectVia(h, "HTTP/1.1", "test-proxy")
 
-	if got := h.Get("Via"); got != "HTTP/1.1 test-proxy" {
+	if got := h.Get(headerVia); got != "HTTP/1.1 test-proxy" {
 		t.Errorf("Via: want %q, got %q", "HTTP/1.1 test-proxy", got)
 	}
 }
 
 func TestInjectVia_AppendsToExisting(t *testing.T) {
-	h := http.Header{"Via": {"1.0 first-proxy"}}
+	h := http.Header{headerVia: {"1.0 first-proxy"}}
 	injectVia(h, "HTTP/1.1", "second-proxy")
 
 	want := "1.0 first-proxy, HTTP/1.1 second-proxy"
-	if got := h.Get("Via"); got != want {
+	if got := h.Get(headerVia); got != want {
 		t.Errorf("Via: want %q, got %q", want, got)
 	}
 }
@@ -985,7 +985,7 @@ func TestHandleClientAppendsToExistingResponseVia(t *testing.T) {
 	}
 
 	want := "1.0 upstream-proxy, HTTP/1.1 " + testPseudonym
-	if got := resp.Header.Get("Via"); got != want {
+	if got := resp.Header.Get(headerVia); got != want {
 		t.Errorf("response Via header = %q, want %q", got, want)
 	}
 
@@ -1037,7 +1037,7 @@ func TestUnparseableUpstreamReturns502(t *testing.T) {
 	assertStatusCode(t, resp, http.StatusBadGateway)
 
 	wantPS := "spnego-proxy; error=http_protocol_error"
-	if got := resp.Header.Get("Proxy-Status"); got != wantPS {
+	if got := resp.Header.Get(headerProxyStatus); got != wantPS {
 		t.Errorf("Proxy-Status: want %q, got %q", wantPS, got)
 	}
 }
@@ -1097,7 +1097,7 @@ func TestHandleClientAddsViaToConnectResponse(t *testing.T) {
 
 	// Verify Via header on the CONNECT response.
 	want := "HTTP/1.1 " + testPseudonym
-	if got := resp.Header.Get("Via"); got != want {
+	if got := resp.Header.Get(headerVia); got != want {
 		t.Errorf("response Via header = %q, want %q", got, want)
 	}
 

--- a/internal/proxy/integration_gss_darwin_test.go
+++ b/internal/proxy/integration_gss_darwin_test.go
@@ -266,8 +266,8 @@ func TestGSSProxyChainWithEphemeralKDC(t *testing.T) {
 			return
 		}
 		_ = req.Body.Close()
-		gotAuth <- req.Header.Get("Proxy-Authorization")
-		gotVia <- req.Header.Get("Via")
+		gotAuth <- req.Header.Get(headerProxyAuthorization)
+		gotVia <- req.Header.Get(headerVia)
 
 		resp := "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
 		_, _ = conn.Write([]byte(resp))

--- a/internal/proxy/main_test.go
+++ b/internal/proxy/main_test.go
@@ -95,7 +95,7 @@ func TestHandleClientReadTimeout(t *testing.T) {
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Errorf("expected status 400, got %d", resp.StatusCode)
 	}
-	if ps := resp.Header.Get("Proxy-Status"); ps != "spnego-proxy; error=http_request_error" {
+	if ps := resp.Header.Get(headerProxyStatus); ps != "spnego-proxy; error=http_request_error" {
 		t.Errorf("expected Proxy-Status header %q, got %q", "spnego-proxy; error=http_request_error", ps)
 	}
 	body, _ := io.ReadAll(resp.Body)
@@ -317,7 +317,7 @@ func TestShutdownDrainsInFlightConnections(t *testing.T) {
 
 	// Verify Via header was added to the relayed response.
 	wantResponseVia := "HTTP/1.1 " + testPseudonym
-	if got := resp.Header.Get("Via"); got != wantResponseVia {
+	if got := resp.Header.Get(headerVia); got != wantResponseVia {
 		t.Errorf("response Via header = %q, want %q", got, wantResponseVia)
 	}
 
@@ -468,7 +468,7 @@ func TestHandleClientForwardsBufferedData(t *testing.T) {
 			gotVia <- "READ_ERR: " + err.Error()
 			return
 		}
-		gotVia <- req.Header.Get("Via")
+		gotVia <- req.Header.Get(headerVia)
 		_ = req.Body.Close()
 
 		// Send 200 to complete the CONNECT handshake.
@@ -513,7 +513,7 @@ func TestHandleClientForwardsBufferedData(t *testing.T) {
 
 	// Verify Via header was added to the relayed response.
 	wantResponseVia := "HTTP/1.1 " + testPseudonym
-	if got := resp.Header.Get("Via"); got != wantResponseVia {
+	if got := resp.Header.Get(headerVia); got != wantResponseVia {
 		t.Errorf("response Via header = %q, want %q", got, wantResponseVia)
 	}
 
@@ -567,7 +567,7 @@ func TestCloseWriteCalledOnForwardCompletion(t *testing.T) {
 		if err != nil {
 			gotVia <- "READ_ERR: " + err.Error()
 		} else {
-			gotVia <- req.Header.Get("Via")
+			gotVia <- req.Header.Get(headerVia)
 			_ = req.Body.Close()
 		}
 		resp := "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
@@ -620,7 +620,7 @@ func TestCloseWriteCalledOnForwardCompletion(t *testing.T) {
 
 	// Verify Via header was added to the relayed response.
 	wantResponseVia := "HTTP/1.1 " + testPseudonym
-	if got := resp.Header.Get("Via"); got != wantResponseVia {
+	if got := resp.Header.Get(headerVia); got != wantResponseVia {
 		t.Errorf("response Via header = %q, want %q", got, wantResponseVia)
 	}
 
@@ -726,7 +726,7 @@ func TestHandleClientKeepAlive(t *testing.T) {
 				if err != nil {
 					gotVia <- "READ_ERR: " + err.Error()
 				} else {
-					gotVia <- req.Header.Get("Via")
+					gotVia <- req.Header.Get(headerVia)
 					_ = req.Body.Close()
 				}
 				resp := "HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nOK"
@@ -768,7 +768,7 @@ func TestHandleClientKeepAlive(t *testing.T) {
 
 	// Verify Via header was added to the relayed response.
 	wantResponseVia := "HTTP/1.1 " + testPseudonym
-	if got := resp.Header.Get("Via"); got != wantResponseVia {
+	if got := resp.Header.Get(headerVia); got != wantResponseVia {
 		t.Errorf("response Via header = %q, want %q", got, wantResponseVia)
 	}
 
@@ -875,7 +875,7 @@ func TestHandleClientRejectsSmuggledRequest(t *testing.T) {
 	if resp2.StatusCode != http.StatusForbidden {
 		t.Fatalf("resp2 status: want 403 (forbidden_port), got %d (body=%q)", resp2.StatusCode, body)
 	}
-	if ps := resp2.Header.Get("Proxy-Status"); ps != "spnego-proxy; error=http_request_denied" {
+	if ps := resp2.Header.Get(headerProxyStatus); ps != "spnego-proxy; error=http_request_denied" {
 		t.Errorf("resp2 Proxy-Status = %q, want http_request_denied", ps)
 	}
 
@@ -947,17 +947,17 @@ func TestHandleClientKeepAliveForwardsSecondRequest(t *testing.T) {
 
 	wantVia := "HTTP/1.1 " + testPseudonym
 	for i, r := range reqs {
-		if v := r.Header.Get("Via"); v != wantVia {
+		if v := r.Header.Get(headerVia); v != wantVia {
 			t.Errorf("req[%d] Via = %q, want %q", i, v, wantVia)
 		}
 	}
-	if pa := reqs[0].Header.Get("Proxy-Authorization"); pa != "Negotiate tok" {
+	if pa := reqs[0].Header.Get(headerProxyAuthorization); pa != "Negotiate tok" {
 		t.Errorf("req[0] Proxy-Authorization = %q, want %q (real proxy token)", pa, "Negotiate tok")
 	}
 	// Subsequent request on an already-authenticated connection: no
 	// Proxy-Authorization. The smuggled "evil-attacker-token" must NOT
 	// reach the upstream.
-	if pa := reqs[1].Header.Get("Proxy-Authorization"); pa != "" {
+	if pa := reqs[1].Header.Get(headerProxyAuthorization); pa != "" {
 		t.Errorf("req[1] Proxy-Authorization = %q, want empty (smuggled token must be stripped, connection auth reused)", pa)
 	}
 	if n := provider.calls.Load(); n != 1 {
@@ -1494,11 +1494,11 @@ func TestRFC4559_ConnectionBoundAuthSingleTokenAcquisition(t *testing.T) {
 		t.Fatalf("upstream received %d requests, want 3", len(reqs))
 	}
 
-	if pa := reqs[0].Header.Get("Proxy-Authorization"); pa != "Negotiate tok" {
+	if pa := reqs[0].Header.Get(headerProxyAuthorization); pa != "Negotiate tok" {
 		t.Errorf("req[0] Proxy-Authorization = %q, want %q", pa, "Negotiate tok")
 	}
 	for i := 1; i < len(reqs); i++ {
-		if pa := reqs[i].Header.Get("Proxy-Authorization"); pa != "" {
+		if pa := reqs[i].Header.Get(headerProxyAuthorization); pa != "" {
 			t.Errorf("req[%d] Proxy-Authorization = %q, want empty (RFC 4559 §5 connection-bound; smuggled tokens MUST be stripped)", i, pa)
 		}
 	}

--- a/internal/proxy/noproxy_integration_test.go
+++ b/internal/proxy/noproxy_integration_test.go
@@ -104,7 +104,7 @@ func TestNoProxyHTTPBypassGoesToTarget(t *testing.T) {
 	assertHeaderPresent(t, resp.Header, "X-Direct", "true")
 
 	// Via must be injected by the proxy per RFC 9110 §7.6.3.
-	via := resp.Header.Get("Via")
+	via := resp.Header.Get(headerVia)
 	if via == "" {
 		t.Error("expected Via header in response, got empty")
 	} else if !strings.Contains(via, testPseudonym) {
@@ -132,7 +132,7 @@ func TestNoProxyNonMatchGoesUpstream(t *testing.T) {
 	})
 
 	// Upstream must have received the request.
-	assertHeaderPresent(t, recorded.Header, "Proxy-Authorization", "Negotiate test-token")
+	assertHeaderPresent(t, recorded.Header, headerProxyAuthorization, "Negotiate test-token")
 }
 
 // TestNoProxyHTTPRequestInOriginForm verifies that when a request is bypassed
@@ -289,7 +289,7 @@ func TestNoProxyCONNECTBypassEstablishesDirectTunnel(t *testing.T) {
 	assertStatusCode(t, resp, http.StatusOK)
 
 	// Via must appear on the 200 response per RFC 9110 §7.6.3.
-	via := resp.Header.Get("Via")
+	via := resp.Header.Get(headerVia)
 	if via == "" {
 		t.Error("expected Via header in CONNECT 200 response, got empty")
 	} else if !strings.Contains(via, testPseudonym) {
@@ -298,8 +298,8 @@ func TestNoProxyCONNECTBypassEstablishesDirectTunnel(t *testing.T) {
 
 	// Content-Length and Connection: close MUST NOT appear — they cause
 	// Bun/undici clients to close the connection before the TLS handshake.
-	assertHeaderAbsent(t, resp.Header, "Content-Length")
-	assertHeaderAbsent(t, resp.Header, "Connection")
+	assertHeaderAbsent(t, resp.Header, headerContentLength)
+	assertHeaderAbsent(t, resp.Header, headerConnection)
 
 	// Verify the tunnel actually works: send data and read the echo back.
 	const payload = "hello-direct-tunnel"

--- a/internal/proxy/protocol_edge_cases_test.go
+++ b/internal/proxy/protocol_edge_cases_test.go
@@ -185,8 +185,8 @@ func TestG1_MaxForwards_Table(t *testing.T) {
 					t.Fatalf("upstream received %d requests, want 1", len(reqs))
 				}
 				if tc.wantMF == "" {
-					assertHeaderAbsent(t, reqs[0].Header, "Max-Forwards")
-				} else if got := reqs[0].Header.Get("Max-Forwards"); got != tc.wantMF {
+					assertHeaderAbsent(t, reqs[0].Header, headerMaxForwards)
+				} else if got := reqs[0].Header.Get(headerMaxForwards); got != tc.wantMF {
 					t.Errorf("upstream Max-Forwards: want %q, got %q", tc.wantMF, got)
 				}
 			} else {
@@ -203,7 +203,7 @@ func TestG1_MaxForwards_Table(t *testing.T) {
 				}
 				// OPTIONS MF=0: Allow header must be present per RFC 9110.
 				if tc.method == "OPTIONS" {
-					if allow := resp.Header.Get("Allow"); allow == "" {
+					if allow := resp.Header.Get(headerAllow); allow == "" {
 						t.Error("OPTIONS MF=0 response missing Allow header")
 					}
 				}

--- a/internal/proxy/proxy_status_test.go
+++ b/internal/proxy/proxy_status_test.go
@@ -45,7 +45,7 @@ func assertProxyStatus(t *testing.T, resp *http.Response, wantCode int, wantErro
 	assertStatusCode(t, resp, wantCode)
 
 	wantPS := "spnego-proxy; error=" + wantErrorType
-	if got := resp.Header.Get("Proxy-Status"); got != wantPS {
+	if got := resp.Header.Get(headerProxyStatus); got != wantPS {
 		t.Errorf("Proxy-Status: want %q, got %q", wantPS, got)
 	}
 }
@@ -182,7 +182,7 @@ func TestA3_RFC9209_ProxyStatusOnProxyInternalError(t *testing.T) {
 			assertProxyStatus(t, resp, http.StatusBadGateway, "proxy_internal_error")
 
 			// Verify the proxy identifier prefix is exactly "spnego-proxy;".
-			ps := resp.Header.Get("Proxy-Status")
+			ps := resp.Header.Get(headerProxyStatus)
 			if !strings.HasPrefix(ps, "spnego-proxy;") {
 				t.Errorf("Proxy-Status %q: identifier must start with %q", ps, "spnego-proxy;")
 			}
@@ -343,7 +343,7 @@ func TestL2_RFC9110_GatewayTimeoutOnDialTimeout(t *testing.T) {
 
 	// RFC 9209: Proxy-Status MUST carry the connection_timeout error token.
 	const wantPS = "spnego-proxy; error=connection_timeout"
-	if got := resp.Header.Get("Proxy-Status"); got != wantPS {
+	if got := resp.Header.Get(headerProxyStatus); got != wantPS {
 		t.Errorf("Proxy-Status: want %q, got %q", wantPS, got)
 	}
 
@@ -402,7 +402,7 @@ func TestL1_RFC9112_BadGatewayOnConnectionRefused(t *testing.T) {
 
 	// RFC 9209: Proxy-Status MUST carry the connection_refused error token.
 	const wantPS = "spnego-proxy; error=connection_refused"
-	if got := resp.Header.Get("Proxy-Status"); got != wantPS {
+	if got := resp.Header.Get(headerProxyStatus); got != wantPS {
 		t.Errorf("Proxy-Status: want %q, got %q", wantPS, got)
 	}
 

--- a/internal/proxy/response_fuzz_test.go
+++ b/internal/proxy/response_fuzz_test.go
@@ -98,7 +98,7 @@ func FuzzContentLengthValues(f *testing.F) {
 	f.Fuzz(func(t *testing.T, raw string) {
 		// '\n'-separated header values; each value may itself be a comma list.
 		values := strings.Split(raw, "\n")
-		resp := &http.Response{Header: http.Header{"Content-Length": values}}
+		resp := &http.Response{Header: http.Header{headerContentLength: values}}
 
 		accepted := validateResponseContentLength(resp) == nil
 		if !accepted {
@@ -150,7 +150,7 @@ func isTcharByte(c byte) bool {
 // them. Only the boolean is asserted (validateResponseHeaderBytes ranges a map
 // and the *blamed* header is non-deterministic; the nil/non-nil result is not).
 func FuzzHeaderByteValidators(f *testing.F) {
-	f.Add("Content-Type", "text/html")
+	f.Add(headerContentType, "text/html")
 	f.Add("X\x01", "v")
 	f.Add("Set-Cookie", "a\rb")
 	f.Add("Set-Cookie", "a\x7fb")


### PR DESCRIPTION
Test-side follow-up to #233.

## Context

#233 introduced `internal/proxy/headers_const.go` (unexported header-name + value constants) and swept production call sites. The test-side sweep was deferred to keep that correctness-sensitive prod diff reviewable.

## Change

Sweeps **133 standalone quoted header-name literals** across **13 white-box (`package proxy`) test files** onto the existing constants. **Header names only** — value literals (`negotiateScheme`/`connectionClose`/`proxyStatusPrefix`) deliberately deferred due to trailing-space / `fmt.Sprintf` format-string / concat-shape traps that would break the mechanical, net-string-equality-provable property.

**Pure mechanical refactor — net string equality preserved byte-for-byte. 476 tests pass unchanged. Zero behaviour change → no SemVer bump** (`refactor:` per CLAUDE.md).

### Intentionally left as literals (data-under-test, not header names)

- `hop_by_hop_test.go:390` — Connection header *value* `{"Proxy-Authorization"}` in the "Connection names Proxy-Authorization" attack fixture
- `hop_by_hop_test.go:656` — Connection *value* `"Via"` in the Via-loop-bypass attack

Constantising these would obscure the attack semantics.

### Untouched

- 0 raw HTTP byte-string fixture lines (`\r\n` framing) modified — verified
- `cli_test.go`, `version_test.go` (`package main` — cannot see unexported consts)
- `assertHeaderPresent`/`assertHeaderAbsent` signatures (only call-site args changed)

## Verification

- `gofmt -l ./internal/proxy/` — clean
- `go build ./...`, `go vet ./...` — pass
- `GOOS=darwin go build ./internal/proxy/` — pass (compile-checks the darwin-tagged in-scope file)
- `go test -count=1 ./...` — **476 passed** (identical to pre-sweep)
- anchored-literal multiset → only the 2 deliberate payloads remain; 13 files / 146↔146 pure substitutions; no `\r\n` line changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)