### PR TITLE
fix: advertise PATCH in Allow header for OPTIONS Max-Forwards:0 responses

### DIFF
--- a/internal/proxy/headers_const.go
+++ b/internal/proxy/headers_const.go
@@ -39,10 +39,10 @@ const (
 // negotiateScheme carries a MANDATORY trailing space (RFC 4559 auth-scheme
 // followed by SP before the token).
 const (
-	negotiateScheme     = "Negotiate "                // RFC 4559; trailing SP REQUIRED — do not trim
-	connectionClose     = "close"                     // Connection header value
-	contentTypeTextUTF8 = "text/plain; charset=utf-8" // exact: single space after ';'
-	proxyStatusPrefix   = "spnego-proxy; error="      // RFC 9209 + RFC 8941; trailing '=' intentional
-	schemeHTTP          = "http"                      // X-Forwarded-Proto default
-	allowMethods        = "GET, HEAD, POST, PUT, DELETE, OPTIONS, TRACE, CONNECT"
+	negotiateScheme     = "Negotiate "                                                   // RFC 4559; trailing SP REQUIRED — do not trim
+	connectionClose     = "close"                                                        // Connection header value
+	contentTypeTextUTF8 = "text/plain; charset=utf-8"                                    // exact: single space after ';'
+	proxyStatusPrefix   = "spnego-proxy; error="                                         // RFC 9209 + RFC 8941; trailing '=' intentional
+	schemeHTTP          = "http"                                                         // X-Forwarded-Proto default
+	allowMethods        = "GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, TRACE, CONNECT" // PATCH per RFC 5789 §3.1
 )

--- a/internal/proxy/protocol_edge_cases_test.go
+++ b/internal/proxy/protocol_edge_cases_test.go
@@ -201,10 +201,15 @@ func TestG1_MaxForwards_Table(t *testing.T) {
 				if len(body) != 0 {
 					t.Errorf("expected empty body for MF=0 local response, got %d bytes: %q", len(body), body)
 				}
-				// OPTIONS MF=0: Allow header must be present per RFC 9110.
+				// OPTIONS MF=0: Allow header must be present per RFC 9110
+				// §9.3.7, and carry the proxy's exact advertised method set
+				// (RFC 9110 §10.1.1; PATCH per RFC 5789 §3.1). Pinning the
+				// literal locks this HTTP-contract surface against drift —
+				// asserting against allowMethods would be tautological.
 				if tc.method == "OPTIONS" {
-					if allow := resp.Header.Get(headerAllow); allow == "" {
-						t.Error("OPTIONS MF=0 response missing Allow header")
+					const wantAllow = "GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, TRACE, CONNECT"
+					if allow := resp.Header.Get(headerAllow); allow != wantAllow {
+						t.Errorf("OPTIONS MF=0 Allow header = %q, want %q", allow, wantAllow)
 					}
 				}
 			}


### PR DESCRIPTION
## What

Add `PATCH` to the `Allow` method set the proxy advertises on the
OPTIONS / `Max-Forwards: 0` path, and pin the exact `Allow` value in
`TestG1_MaxForwards_Table`.

`internal/proxy/headers_const.go`:
`"GET, HEAD, POST, PUT, DELETE, OPTIONS, TRACE, CONNECT"` →
`"GET, HEAD, POST, PUT, DELETE, PATCH, OPTIONS, TRACE, CONNECT"`

## Why

The proxy is method-agnostic — it forwards every method (including PATCH)
and rejects none. On the OPTIONS / `Max-Forwards: 0` path (RFC 9110
§7.6.2) it is the final recipient and manufactures a local `200 OK`
whose `Allow` header advertises its method set (RFC 9110 §9.3.7,
§10.1.1). That set listed every core method **except** PATCH — the one
method an RFC explicitly directs servers to advertise (RFC 5789 §3.1).
Closing that single standards gap; the list is representative, not
exhaustive (HTTP has no wildcard; empty `Allow` means "no methods"), so
WebDAV/extension methods remain out of scope.

The test previously asserted only that `Allow` was *present*; it now
asserts the exact literal, locking this HTTP-contract surface against
silent drift (CLAUDE.md SemVer: HTTP response headers are contract).

## Compatibility

Additive to an advertised header value. No method was rejected before and
none is now → **non-breaking, patch-level** (`fix:`).

## Verification

- `go test -count=1 ./...` → 476 passed
- `golangci-lint run` → 0 issues
- TDD: assertion tightened first (RED — old value lacked PATCH), then
  constant updated (GREEN)

🤖 Generated with [Claude Code](https://claude.com/claude-code)