### PR TITLE
refactor: introduce ClientSession; convert request handlers to methods (#236)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,66 @@
+# CONTEXT — spnego-proxy domain glossary
+
+The vocabulary engineering work should use when naming concepts in this
+repo (issue titles, refactor proposals, hypotheses, test names). One
+context (the proxy core in `internal/proxy`). Keep terms here in sync as
+decisions crystallise; record decisions as ADRs under `docs/adr/`.
+
+## Glossary
+
+- **Client Session** — the per-connection unit of work: one accepted
+  client TCP connection plus the state that lives for its duration
+  (config snapshot, the buffered request reader, the lazily-dialled
+  upstream connection and its reader). Represented by the `ClientSession`
+  type (`internal/proxy/session.go`); see [ADR-0001](docs/adr/0001-introduce-client-session-handling-layer.md).
+
+- **Keep-Alive Loop** — the loop in `ClientSession.run` that reads,
+  validates, and relays successive HTTP requests over one persistent
+  client connection until either side signals close (see *Connection
+  Close Signal*) or an error occurs.
+
+- **Forward** — relaying an HTTP request and its response with
+  request/response framing preserved (as opposed to *Tunnel*). The
+  via-upstream HTTP relay lives in `ClientSession.run`; the noproxy
+  variant is `ClientSession.forwardDirect`.
+
+- **Tunnel** — opaque bidirectional byte relay established after a
+  CONNECT, with no HTTP framing. Methods: `ClientSession.tunnelViaUpstream`
+  (through the upstream proxy) and `ClientSession.tunnelDirect` (noproxy);
+  the byte-pump primitive is `handleConnectTunnel` / `forwardHalf`.
+
+- **Via-Upstream** — traffic routed through the SPNEGO/Kerberos-
+  authenticated upstream proxy, carrying `Proxy-Authorization: Negotiate
+  <token>`.
+
+- **Direct (noproxy bypass)** — traffic for a host matching the `NoProxy`
+  matcher that the proxy dials itself, bypassing the upstream proxy and
+  SPNEGO entirely.
+
+- **Validation Pipeline** — the per-request pre-forward checks run on
+  every keep-alive iteration: Via loop detection, CONNECT port allowlist,
+  Max-Forwards decrement, and hop-by-hop sanitisation
+  (`ClientSession.validateRequest`).
+
+- **Hop-by-Hop Sanitisation** — stripping connection-scoped headers
+  (notably a smuggled `Proxy-Authorization`) on every iteration so a
+  later request cannot ride a prior authenticated upstream connection.
+
+- **Lazy Upstream Dial / Connection Reuse** — the upstream proxy
+  connection is dialled on the first via-upstream plain-HTTP request and
+  reused for subsequent ones (RFC 4559 §5); a CONNECT always dials a
+  fresh connection because a tunnel co-opts the socket for opaque bytes.
+
+- **Connection Close Signal** — the condition, computed by
+  `connectionWillClose`, under which the keep-alive loop must stop:
+  HTTP/1.0 client (RFC 9112 §9.3), or `Connection: close` on either side.
+
+- **Frozen Seam** — `handleClient(conn, cfg)`: the stable entry point
+  called by `Serve` and the test harness. Its signature is deliberately
+  held constant so internal refactors do not ripple into callers or
+  tests; see [ADR-0001](docs/adr/0001-introduce-client-session-handling-layer.md).
+
+- **CLI Contract Surface** — the SemVer-relevant public API: CLI flags
+  (names, types, defaults), exit codes, stdout/stderr behaviour, HTTP
+  response headers and error format, and CONNECT tunnelling behaviour.
+  Internal restructuring that leaves this surface untouched is not a
+  breaking change.

--- a/docs/adr/0001-introduce-client-session-handling-layer.md
+++ b/docs/adr/0001-introduce-client-session-handling-layer.md
@@ -1,0 +1,87 @@
+# ADR 0001 — Introduce a per-connection handling layer (`ClientSession`)
+
+- Status: Accepted
+- Date: 2026-05-17
+- Issue: [#236](https://github.com/andrewesweet/spnego-proxy/issues/236)
+
+## Context
+
+`internal/proxy` had no request-handling layer object. Per-connection
+orchestration was a set of free functions sharing the
+`(conn, req, cfg, clientAddr)` tuple by convention. `forward.go` was a
+god-file mixing four jobs: the validation pipeline
+(`prepareForwardRequest`), dial+auth (`dialAndAuthUpstream`), the 145-line
+keep-alive loop (`handleClient`), and CONNECT-via-upstream
+(`forwardConnectViaUpstream`). `Config` (13 fields) was threaded whole
+through 7 functions — 22 parameter sites, 42 field-read sites — so the
+data dependency of each handler was invisible at its call boundary. The
+implicit per-connection contract (e.g. "create the buffered request
+reader exactly once, or pipelining silently breaks") was undocumented and
+easy to violate.
+
+Surfaced by a whole-codebase architecture review (findings F1 god-file,
+F4 fat `Config`, F8 generic `handle*` names, F13 no handling layer). The
+deletion test confirmed depth rather than a pass-through: removing a
+hypothetical session reintroduces the same tuple across all 7 functions.
+
+A material constraint shaped the decision: `handleClient(conn, cfg)` is
+called directly by ~7 test files and by `Serve`. Constructing the session
+"in `Serve`'s goroutine" (the original proposal wording) would have
+forced edits to `server.go` and every test seam and risked reordering the
+issue-#75 LIFO close defers.
+
+## Decision
+
+Introduce `ClientSession{conn, cfg, clientAddr, reqReader, proxyConn,
+upstreamReader}`, constructed **inside `handleClient`** — not in `Serve`'s
+goroutine — so `handleClient(conn net.Conn, cfg Config)` remains a
+**Frozen Seam** for `Serve` and the test harness. The connection-level
+cleanup defers (conn close / closeWrite / proxyConn close) stay in
+`handleClient`, preserving the issue-#75 LIFO ordering exactly.
+
+Convert the four sub-flows and the keep-alive loop to methods named for
+the domain: `run`, `validateRequest`, `dialAndAuthUpstream` (kept its
+`net.Conn` return so the reused keep-alive `s.proxyConn` and the fresh
+per-CONNECT method-local conn cannot alias), `tunnelViaUpstream`,
+`tunnelDirect`, `forwardDirect`. Replace wide `Config` threading with
+`s.cfg`.
+
+Keep `handleConnectTunnel` a free function with its narrow scalar
+signature (the session destructures itself at the call site), and keep
+the pure helpers (`connectionWillClose`, `dialDirect`, `sameHost`,
+`handleDialError`, `stripIPv6Brackets`) free — methodising them would add
+no locality.
+
+Migration executed as nine substitution-only `refactor:` commits with the
+full test suite green at each step.
+
+## Consequences
+
+- (+) Per-connection state, its lifetime, and ownership rules (single
+  `reqReader`; lazily-dialled, reused `proxyConn`) are explicit in one
+  type and enforced by structure rather than convention.
+- (+) Handler signatures shrink to the per-request `*http.Request`;
+  `Config` plumbing collapses to `s.cfg`. Handler names now reveal the
+  domain (forward vs tunnel, via-upstream vs direct).
+- (+) `handleClient` stays a one-screen constructor + dispatch shim; its
+  call seam for `Serve` and tests is unchanged, which is what made the
+  incremental green migration possible (the test/`server.go` diff against
+  the pre-refactor commit is empty).
+- (−) One more type and an `s.` indirection on the hot path; negligible
+  (one struct allocation per connection, equivalent to the previous
+  pass-by-value `Config`).
+- (−) `handleConnectTunnel`'s deliberate decoupling means the session
+  must destructure itself at that one call site (accepted: keeps the
+  tunnel primitive minimal and independently testable).
+- Zero behaviour change. Not SemVer-relevant — the CLI Contract Surface
+  is untouched; `refactor:`/`docs:` commits only, no release triggered.
+
+## Fuzz-target gate (issue #236 subtask)
+
+No new fuzz target is mandated by this refactor: it introduces no new
+parseable-input surface (same `http.ReadRequest`, same validation
+pipeline, same `resp.Write`, relocated onto methods). The 7 existing
+leaf-function `Fuzz*` targets are unaffected. A pre-existing coverage gap
+— no target exercises the per-connection keep-alive request-reading loop
+(bufio state across pipelined requests + drain + framing) — predates this
+work and is tracked separately, not as a blocker for #236.

--- a/internal/proxy/direct.go
+++ b/internal/proxy/direct.go
@@ -67,7 +67,7 @@ func handleDialError(conn net.Conn, err error, target, clientAddr, path string) 
 	}
 }
 
-// handleDirectHTTP forwards an HTTP request directly to the target host,
+// forwardDirect forwards an HTTP request directly to the target host,
 // bypassing the upstream proxy. Used for noproxy bypass of non-CONNECT
 // requests. The request is converted from absolute-URI (proxy form) to
 // origin form.
@@ -77,17 +77,17 @@ func handleDialError(conn net.Conn, err error, target, clientAddr, path string) 
 // a different host are rejected with errMismatchedTarget so a smuggled
 // second request cannot ride the existing direct TCP connection to a
 // target it was never authorised for.
-func handleDirectHTTP(conn net.Conn, req *http.Request, reqReader *bufio.Reader, cfg Config, clientAddr string) {
-	targetConn, target, err := dialDirect(req.Host, "80", cfg.DialTimeout)
+func (s *ClientSession) forwardDirect(req *http.Request) {
+	targetConn, target, err := dialDirect(req.Host, "80", s.cfg.DialTimeout)
 	if err != nil {
-		handleDialError(conn, err, target, clientAddr, "HTTP")
+		handleDialError(s.conn, err, target, s.clientAddr, "HTTP")
 		return
 	}
 	defer func() { _ = targetConn.Close() }()
 
-	if cfg.KeepAlive > 0 {
-		enableKeepAlive(conn, cfg.KeepAlive)
-		enableKeepAlive(targetConn, cfg.KeepAlive)
+	if s.cfg.KeepAlive > 0 {
+		enableKeepAlive(s.conn, s.cfg.KeepAlive)
+		enableKeepAlive(targetConn, s.cfg.KeepAlive)
 	}
 
 	boundHost := req.Host
@@ -95,67 +95,67 @@ func handleDirectHTTP(conn net.Conn, req *http.Request, reqReader *bufio.Reader,
 
 	for iter := 0; ; iter++ {
 		if iter > 0 {
-			_ = conn.SetReadDeadline(time.Now().Add(cfg.ReadTimeout))
-			nextReq, rerr := http.ReadRequest(reqReader)
-			_ = conn.SetReadDeadline(time.Time{})
+			_ = s.conn.SetReadDeadline(time.Now().Add(s.cfg.ReadTimeout))
+			nextReq, rerr := http.ReadRequest(s.reqReader)
+			_ = s.conn.SetReadDeadline(time.Time{})
 			if rerr != nil {
-				slog.Debug("noproxy keep-alive loop ended", "error", rerr, "target", target, "iter", iter, "client_addr", clientAddr)
+				slog.Debug("noproxy keep-alive loop ended", "error", rerr, "target", target, "iter", iter, "client_addr", s.clientAddr)
 				return
 			}
-			proceed, pe := prepareForwardRequest(conn, nextReq, cfg, clientAddr)
+			proceed, pe := prepareForwardRequest(s.conn, nextReq, s.cfg, s.clientAddr)
 			if !proceed {
 				if pe != nil {
-					writeHTTPError(conn, pe)
+					writeHTTPError(s.conn, pe)
 				}
 				return
 			}
 			// A direct TCP connection is bound to a single target host;
 			// reject pipelined requests for any other host.
 			if !sameHost(nextReq.Host, boundHost, "80") {
-				slog.Warn("noproxy pipelined request targets different host", "bound_host", boundHost, "request_host", nextReq.Host, "client_addr", clientAddr)
-				writeHTTPError(conn, errMismatchedTarget)
+				slog.Warn("noproxy pipelined request targets different host", "bound_host", boundHost, "request_host", nextReq.Host, "client_addr", s.clientAddr)
+				writeHTTPError(s.conn, errMismatchedTarget)
 				return
 			}
 			// CONNECT on a plain-HTTP direct connection: cannot tunnel
 			// on a connection used for HTTP responses.
 			if nextReq.Method == http.MethodConnect {
-				slog.Warn("noproxy pipelined CONNECT on HTTP connection", "client_addr", clientAddr)
-				writeHTTPError(conn, errMismatchedTarget)
+				slog.Warn("noproxy pipelined CONNECT on HTTP connection", "client_addr", s.clientAddr)
+				writeHTTPError(s.conn, errMismatchedTarget)
 				return
 			}
-			injectVia(nextReq.Header, nextReq.Proto, cfg.Pseudonym)
+			injectVia(nextReq.Header, nextReq.Proto, s.cfg.Pseudonym)
 			req = nextReq
 		}
 
 		// Write request in origin form (not proxy form).
 		if err := req.Write(targetConn); err != nil {
 			if isExpectedCloseError(err) {
-				slog.Debug("noproxy write request closed", "error", err, "target", target, "client_addr", clientAddr)
+				slog.Debug("noproxy write request closed", "error", err, "target", target, "client_addr", s.clientAddr)
 			} else {
-				slog.Error("noproxy write request failed", "error", err, "target", target, "client_addr", clientAddr)
+				slog.Error("noproxy write request failed", "error", err, "target", target, "client_addr", s.clientAddr)
 			}
-			writeHTTPError(conn, errConnectionTerminated)
+			writeHTTPError(s.conn, errConnectionTerminated)
 			return
 		}
 
-		slog.Debug("noproxy HTTP response forwarding start", "target", target, "client_addr", clientAddr, "iter", iter)
+		slog.Debug("noproxy HTTP response forwarding start", "target", target, "client_addr", s.clientAddr, "iter", iter)
 		resp, rerr := http.ReadResponse(upstreamReader, req)
 		if rerr != nil {
 			if isExpectedCloseError(rerr) {
-				slog.Debug("noproxy read response closed", "error", rerr, "target", target, "client_addr", clientAddr)
+				slog.Debug("noproxy read response closed", "error", rerr, "target", target, "client_addr", s.clientAddr)
 			} else {
-				slog.Error("noproxy read response failed", "error", rerr, "target", target, "client_addr", clientAddr)
+				slog.Error("noproxy read response failed", "error", rerr, "target", target, "client_addr", s.clientAddr)
 			}
 			return
 		}
-		injectVia(resp.Header, resp.Proto, cfg.Pseudonym)
-		writeErr := resp.Write(conn)
+		injectVia(resp.Header, resp.Proto, s.cfg.Pseudonym)
+		writeErr := resp.Write(s.conn)
 		if writeErr != nil {
 			_ = resp.Body.Close()
 			if isExpectedCloseError(writeErr) {
-				slog.Debug("noproxy forward response closed", "error", writeErr, "target", target, "client_addr", clientAddr)
+				slog.Debug("noproxy forward response closed", "error", writeErr, "target", target, "client_addr", s.clientAddr)
 			} else {
-				slog.Error("noproxy forward response failed", "error", writeErr, "target", target, "client_addr", clientAddr)
+				slog.Error("noproxy forward response failed", "error", writeErr, "target", target, "client_addr", s.clientAddr)
 			}
 			return
 		}
@@ -164,11 +164,11 @@ func handleDirectHTTP(conn net.Conn, req *http.Request, reqReader *bufio.Reader,
 		// risks response misframing, so close instead of looping.
 		if _, derr := io.Copy(io.Discard, resp.Body); derr != nil {
 			_ = resp.Body.Close()
-			slog.Debug("noproxy upstream body drain failed, closing connection", "error", derr, "target", target, "client_addr", clientAddr)
+			slog.Debug("noproxy upstream body drain failed, closing connection", "error", derr, "target", target, "client_addr", s.clientAddr)
 			return
 		}
 		_ = resp.Body.Close()
-		slog.Debug("noproxy HTTP response forwarding done", "target", target, "client_addr", clientAddr, "iter", iter)
+		slog.Debug("noproxy HTTP response forwarding done", "target", target, "client_addr", s.clientAddr, "iter", iter)
 
 		if connectionWillClose(req, resp) {
 			return

--- a/internal/proxy/direct.go
+++ b/internal/proxy/direct.go
@@ -102,7 +102,7 @@ func (s *ClientSession) forwardDirect(req *http.Request) {
 				slog.Debug("noproxy keep-alive loop ended", "error", rerr, "target", target, "iter", iter, "client_addr", s.clientAddr)
 				return
 			}
-			proceed, pe := prepareForwardRequest(s.conn, nextReq, s.cfg, s.clientAddr)
+			proceed, pe := s.validateRequest(nextReq)
 			if !proceed {
 				if pe != nil {
 					writeHTTPError(s.conn, pe)

--- a/internal/proxy/direct.go
+++ b/internal/proxy/direct.go
@@ -176,14 +176,15 @@ func handleDirectHTTP(conn net.Conn, req *http.Request, reqReader *bufio.Reader,
 	}
 }
 
-// handleDirectConnect establishes a direct TCP tunnel to the target host,
+// tunnelDirect establishes a direct TCP tunnel to the target host,
 // bypassing the upstream proxy. Used for noproxy bypass of CONNECT requests.
 // Via is injected on the 200 response (not on req.Header, which is never
-// forwarded for CONNECT tunnels).
-func handleDirectConnect(conn net.Conn, req *http.Request, reqReader *bufio.Reader, cfg Config, clientAddr string) {
-	targetConn, target, err := dialDirect(req.Host, "443", cfg.DialTimeout)
+// forwarded for CONNECT tunnels). targetConn is method-local (the noproxy
+// connection is single-target and never reused as s.proxyConn).
+func (s *ClientSession) tunnelDirect(req *http.Request) {
+	targetConn, target, err := dialDirect(req.Host, "443", s.cfg.DialTimeout)
 	if err != nil {
-		handleDialError(conn, err, target, clientAddr, "CONNECT")
+		handleDialError(s.conn, err, target, s.clientAddr, "CONNECT")
 		return
 	}
 	defer func() { _ = targetConn.Close() }()
@@ -194,28 +195,28 @@ func handleDirectConnect(conn net.Conn, req *http.Request, reqReader *bufio.Read
 		ProtoMinor: 1,
 		Header:     make(http.Header),
 	}
-	injectVia(resp.Header, req.Proto, cfg.Pseudonym)
-	if err := writeConnectOK(conn, resp); err != nil {
+	injectVia(resp.Header, req.Proto, s.cfg.Pseudonym)
+	if err := writeConnectOK(s.conn, resp); err != nil {
 		if isExpectedCloseError(err) {
-			slog.Debug("noproxy CONNECT response write closed", "error", err, "target", target, "client_addr", clientAddr)
+			slog.Debug("noproxy CONNECT response write closed", "error", err, "target", target, "client_addr", s.clientAddr)
 		} else {
-			slog.Error("noproxy CONNECT response write failed", "error", err, "target", target, "client_addr", clientAddr)
+			slog.Error("noproxy CONNECT response write failed", "error", err, "target", target, "client_addr", s.clientAddr)
 		}
 		return
 	}
 
-	if cfg.KeepAlive > 0 {
-		enableKeepAlive(conn, cfg.KeepAlive)
-		enableKeepAlive(targetConn, cfg.KeepAlive)
+	if s.cfg.KeepAlive > 0 {
+		enableKeepAlive(s.conn, s.cfg.KeepAlive)
+		enableKeepAlive(targetConn, s.cfg.KeepAlive)
 	}
 
-	slog.Debug("noproxy CONNECT tunnel established", "target", target, "client_addr", clientAddr)
+	slog.Debug("noproxy CONNECT tunnel established", "target", target, "client_addr", s.clientAddr)
 	var wg sync.WaitGroup
 	wg.Go(func() {
-		forwardHalf(targetConn, reqReader, conn, conn.RemoteAddr(), targetConn.RemoteAddr(), cfg.IdleTimeout)
+		forwardHalf(targetConn, s.reqReader, s.conn, s.conn.RemoteAddr(), targetConn.RemoteAddr(), s.cfg.IdleTimeout)
 	})
 	wg.Go(func() {
-		forwardHalf(conn, bufio.NewReader(targetConn), targetConn, targetConn.RemoteAddr(), conn.RemoteAddr(), cfg.IdleTimeout)
+		forwardHalf(s.conn, bufio.NewReader(targetConn), targetConn, targetConn.RemoteAddr(), s.conn.RemoteAddr(), s.cfg.IdleTimeout)
 	})
 	wg.Wait()
 }

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -12,7 +12,7 @@ import (
 	"time"
 )
 
-// prepareForwardRequest runs the per-request validation pipeline shared by
+// validateRequest runs the per-request validation pipeline shared by
 // every iteration of the client-facing keep-alive loop (issue #215). It
 // performs, in order: Via loop detection, CONNECT port allowlist,
 // Max-Forwards decrement (with local response for the terminal case), and
@@ -27,24 +27,24 @@ import (
 //
 // Noproxy matching and forwarding-header injection are NOT performed here;
 // they are caller-side routing decisions that vary by call site.
-func prepareForwardRequest(conn net.Conn, req *http.Request, cfg Config, clientAddr string) (proceed bool, pe *proxyError) {
+func (s *ClientSession) validateRequest(req *http.Request) (proceed bool, pe *proxyError) {
 	// RFC 9110 §7.6.3: loop detection must run BEFORE sanitizeHopByHop so
 	// that a client sending "Connection: Via" cannot strip Via and bypass
 	// the check.
-	if prior := req.Header.Get(headerVia); prior != "" && strings.Contains(prior, cfg.Pseudonym) {
-		slog.Warn("proxy loop detected", "via", prior, "pseudonym", cfg.Pseudonym, "client_addr", clientAddr, "method", req.Method, "host", req.Host)
+	if prior := req.Header.Get(headerVia); prior != "" && strings.Contains(prior, s.cfg.Pseudonym) {
+		slog.Warn("proxy loop detected", "via", prior, "pseudonym", s.cfg.Pseudonym, "client_addr", s.clientAddr, "method", req.Method, "host", req.Host)
 		return false, errProxyLoopDetected
 	}
 
 	// D4 (RFC 9110 §9.3.6): restrict CONNECT to allowed ports.
-	if req.Method == http.MethodConnect && len(cfg.ConnectPorts) > 0 {
+	if req.Method == http.MethodConnect && len(s.cfg.ConnectPorts) > 0 {
 		_, port, err := net.SplitHostPort(req.Host)
 		if err != nil {
-			slog.Debug("CONNECT host has no explicit port, defaulting to 443", "host", req.Host, "error", err, "client_addr", clientAddr)
+			slog.Debug("CONNECT host has no explicit port, defaulting to 443", "host", req.Host, "error", err, "client_addr", s.clientAddr)
 			port = "443"
 		}
-		if !connectPortAllowed(port, cfg.ConnectPorts) {
-			slog.Warn("CONNECT port not allowed", "host", req.Host, "port", port, "client_addr", clientAddr)
+		if !connectPortAllowed(port, s.cfg.ConnectPorts) {
+			slog.Warn("CONNECT port not allowed", "host", req.Host, "port", port, "client_addr", s.clientAddr)
 			return false, errForbiddenPort
 		}
 	}
@@ -55,10 +55,10 @@ func prepareForwardRequest(conn net.Conn, req *http.Request, cfg Config, clientA
 			n, err := strconv.Atoi(mf)
 			switch {
 			case err != nil:
-				slog.Debug("non-numeric Max-Forwards value, forwarding unmodified", "max_forwards", mf, "client_addr", clientAddr)
+				slog.Debug("non-numeric Max-Forwards value, forwarding unmodified", "max_forwards", mf, "client_addr", s.clientAddr)
 			case n <= 0:
-				slog.Debug("Max-Forwards: 0, responding locally", "method", req.Method, "client_addr", clientAddr)
-				writeMaxForwardsResponse(conn, req)
+				slog.Debug("Max-Forwards: 0, responding locally", "method", req.Method, "client_addr", s.clientAddr)
+				writeMaxForwardsResponse(s.conn, req)
 				return false, nil
 			default:
 				req.Header.Set(headerMaxForwards, strconv.Itoa(n-1))
@@ -199,7 +199,7 @@ func (s *ClientSession) run() {
 			return
 		}
 
-		proceed, pe := prepareForwardRequest(s.conn, req, s.cfg, s.clientAddr)
+		proceed, pe := s.validateRequest(req)
 		if !proceed {
 			if pe != nil {
 				writeHTTPError(s.conn, pe)

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -167,6 +167,16 @@ func handleClient(conn net.Conn, cfg Config) {
 		}
 	}()
 
+	s.run()
+}
+
+// run executes the client-facing keep-alive loop: read a request, run the
+// validation pipeline, route it (noproxy bypass, CONNECT-via-upstream, or
+// plain HTTP through the upstream proxy), and repeat until either side
+// signals close or an error occurs. The session's conn close / closeWrite
+// and proxyConn cleanup defers stay in handleClient and fire when run
+// returns, preserving the issue #75 LIFO ordering.
+func (s *ClientSession) run() {
 	for iter := 0; ; iter++ {
 		_ = s.conn.SetReadDeadline(time.Now().Add(s.cfg.ReadTimeout))
 		req, err := http.ReadRequest(s.reqReader)

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -220,7 +220,7 @@ func (s *ClientSession) run() {
 				s.tunnelDirect(req)
 			} else {
 				injectVia(req.Header, req.Proto, s.cfg.Pseudonym)
-				handleDirectHTTP(s.conn, req, s.reqReader, s.cfg, s.clientAddr)
+				s.forwardDirect(req)
 			}
 			return
 		}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -88,33 +88,37 @@ func connectionWillClose(req *http.Request, resp *http.Response) bool {
 
 // dialAndAuthUpstream acquires a SPNEGO token, sets Proxy-Authorization on
 // req, dials the upstream proxy, and enables TCP keepalive on both
-// sockets when configured. On any failure it writes a proxyError to conn
-// and returns nil. Returns the open upstream connection on success.
-func dialAndAuthUpstream(conn net.Conn, req *http.Request, cfg Config, clientAddr string) net.Conn {
-	token, terr := cfg.Provider.GetToken()
+// sockets when configured. On any failure it writes a proxyError to the
+// client conn and returns nil. Returns the open upstream connection on
+// success. The connection is RETURNED rather than stored on the session:
+// the keep-alive path assigns it to s.proxyConn (reused across iterations)
+// while tunnelViaUpstream keeps it method-local (fresh per CONNECT), so
+// the two must not alias.
+func (s *ClientSession) dialAndAuthUpstream(req *http.Request) net.Conn {
+	token, terr := s.cfg.Provider.GetToken()
 	if terr != nil {
 		pe := tokenErrorToProxyError(terr)
-		slog.Error("failed to get SPNEGO token", "error", terr, "error_type", pe.errorType, "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "method", req.Method, "host", req.Host)
-		writeHTTPError(conn, pe)
+		slog.Error("failed to get SPNEGO token", "error", terr, "error_type", pe.errorType, "client_addr", s.clientAddr, "upstream_addr", s.cfg.Upstream, "method", req.Method, "host", req.Host)
+		writeHTTPError(s.conn, pe)
 		return nil
 	}
 	req.Header.Set(headerProxyAuthorization, negotiateScheme+token)
 
-	proxyConn, derr := dialUpstream(cfg.Upstream, cfg.UpstreamTLS)
+	proxyConn, derr := dialUpstream(s.cfg.Upstream, s.cfg.UpstreamTLS)
 	if derr != nil {
 		var ne net.Error
 		if errors.As(derr, &ne) && ne.Timeout() {
-			slog.Error("failed to connect to proxy", "error", derr, "error_type", errConnectionTimeout.errorType, "client_addr", clientAddr, "upstream_addr", cfg.Upstream)
-			writeHTTPError(conn, errConnectionTimeout)
+			slog.Error("failed to connect to proxy", "error", derr, "error_type", errConnectionTimeout.errorType, "client_addr", s.clientAddr, "upstream_addr", s.cfg.Upstream)
+			writeHTTPError(s.conn, errConnectionTimeout)
 		} else {
-			slog.Error("failed to connect to proxy", "error", derr, "error_type", errConnectionRefused.errorType, "client_addr", clientAddr, "upstream_addr", cfg.Upstream)
-			writeHTTPError(conn, errConnectionRefused)
+			slog.Error("failed to connect to proxy", "error", derr, "error_type", errConnectionRefused.errorType, "client_addr", s.clientAddr, "upstream_addr", s.cfg.Upstream)
+			writeHTTPError(s.conn, errConnectionRefused)
 		}
 		return nil
 	}
-	if cfg.KeepAlive > 0 {
-		enableKeepAlive(conn, cfg.KeepAlive)
-		enableKeepAlive(proxyConn, cfg.KeepAlive)
+	if s.cfg.KeepAlive > 0 {
+		enableKeepAlive(s.conn, s.cfg.KeepAlive)
+		enableKeepAlive(proxyConn, s.cfg.KeepAlive)
 	}
 	return proxyConn
 }
@@ -236,7 +240,7 @@ func (s *ClientSession) run() {
 		// connection on subsequent requests (RFC 4559 §5).
 		injectForwardingHeaders(req, s.clientAddr, s.cfg.Forwarding)
 		if s.proxyConn == nil {
-			s.proxyConn = dialAndAuthUpstream(s.conn, req, s.cfg, s.clientAddr)
+			s.proxyConn = s.dialAndAuthUpstream(req)
 			if s.proxyConn == nil {
 				return
 			}
@@ -292,7 +296,7 @@ func (s *ClientSession) run() {
 func (s *ClientSession) tunnelViaUpstream(req *http.Request) {
 	injectForwardingHeaders(req, s.clientAddr, s.cfg.Forwarding)
 
-	proxyConn := dialAndAuthUpstream(s.conn, req, s.cfg, s.clientAddr)
+	proxyConn := s.dialAndAuthUpstream(req)
 	if proxyConn == nil {
 		return
 	}

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -155,38 +155,40 @@ func handleClient(conn net.Conn, cfg Config) {
 	slog.Debug("new client", "client_addr", clientAddr)
 	defer slog.Debug("stop processing request", "client_addr", clientAddr)
 
-	reqReader := bufio.NewReader(conn)
-
-	var proxyConn net.Conn
-	var upstreamReader *bufio.Reader
+	s := &ClientSession{
+		conn:       conn,
+		cfg:        cfg,
+		clientAddr: clientAddr,
+		reqReader:  bufio.NewReader(conn),
+	}
 	defer func() {
-		if proxyConn != nil {
-			_ = proxyConn.Close()
+		if s.proxyConn != nil {
+			_ = s.proxyConn.Close()
 		}
 	}()
 
 	for iter := 0; ; iter++ {
-		_ = conn.SetReadDeadline(time.Now().Add(cfg.ReadTimeout))
-		req, err := http.ReadRequest(reqReader)
-		_ = conn.SetReadDeadline(time.Time{})
+		_ = s.conn.SetReadDeadline(time.Now().Add(s.cfg.ReadTimeout))
+		req, err := http.ReadRequest(s.reqReader)
+		_ = s.conn.SetReadDeadline(time.Time{})
 		if err != nil {
 			if iter == 0 {
 				if isExpectedCloseError(err) {
-					slog.Debug("client connection closed before request", "error", err, "client_addr", clientAddr)
+					slog.Debug("client connection closed before request", "error", err, "client_addr", s.clientAddr)
 				} else {
-					slog.Error("failed to read request", "error", err, "error_type", errHTTPRequestError.errorType, "client_addr", clientAddr)
-					writeHTTPError(conn, errHTTPRequestError)
+					slog.Error("failed to read request", "error", err, "error_type", errHTTPRequestError.errorType, "client_addr", s.clientAddr)
+					writeHTTPError(s.conn, errHTTPRequestError)
 				}
 			} else {
-				slog.Debug("keep-alive loop ended", "error", err, "iter", iter, "client_addr", clientAddr)
+				slog.Debug("keep-alive loop ended", "error", err, "iter", iter, "client_addr", s.clientAddr)
 			}
 			return
 		}
 
-		proceed, pe := prepareForwardRequest(conn, req, cfg, clientAddr)
+		proceed, pe := prepareForwardRequest(s.conn, req, s.cfg, s.clientAddr)
 		if !proceed {
 			if pe != nil {
-				writeHTTPError(conn, pe)
+				writeHTTPError(s.conn, pe)
 			}
 			return
 		}
@@ -195,16 +197,16 @@ func handleClient(conn net.Conn, cfg Config) {
 		// keep-alive loop because the authenticated upstream connection
 		// (if any) cannot serve a direct-dial request.
 		matched, pattern := false, ""
-		if cfg.NoProxy != nil {
-			matched, pattern = cfg.NoProxy.Match(req.Host)
+		if s.cfg.NoProxy != nil {
+			matched, pattern = s.cfg.NoProxy.Match(req.Host)
 		}
 		if matched {
-			slog.Debug("noproxy bypass", "host", req.Host, "pattern", pattern, "method", req.Method, "client_addr", clientAddr)
+			slog.Debug("noproxy bypass", "host", req.Host, "pattern", pattern, "method", req.Method, "client_addr", s.clientAddr)
 			if req.Method == http.MethodConnect {
-				handleDirectConnect(conn, req, reqReader, cfg, clientAddr)
+				handleDirectConnect(s.conn, req, s.reqReader, s.cfg, s.clientAddr)
 			} else {
-				injectVia(req.Header, req.Proto, cfg.Pseudonym)
-				handleDirectHTTP(conn, req, reqReader, cfg, clientAddr)
+				injectVia(req.Header, req.Proto, s.cfg.Pseudonym)
+				handleDirectHTTP(s.conn, req, s.reqReader, s.cfg, s.clientAddr)
 			}
 			return
 		}
@@ -215,40 +217,40 @@ func handleClient(conn net.Conn, cfg Config) {
 		// cannot share with prior HTTP responses on the keep-alive
 		// connection.
 		if req.Method == http.MethodConnect {
-			forwardConnectViaUpstream(conn, req, reqReader, cfg, clientAddr)
+			forwardConnectViaUpstream(s.conn, req, s.reqReader, s.cfg, s.clientAddr)
 			return
 		}
 
 		// Plain HTTP through upstream proxy. Lazy-dial on the first
 		// non-CONNECT, non-noproxy request; reuse the SPNEGO-authenticated
 		// connection on subsequent requests (RFC 4559 §5).
-		injectForwardingHeaders(req, clientAddr, cfg.Forwarding)
-		if proxyConn == nil {
-			proxyConn = dialAndAuthUpstream(conn, req, cfg, clientAddr)
-			if proxyConn == nil {
+		injectForwardingHeaders(req, s.clientAddr, s.cfg.Forwarding)
+		if s.proxyConn == nil {
+			s.proxyConn = dialAndAuthUpstream(s.conn, req, s.cfg, s.clientAddr)
+			if s.proxyConn == nil {
 				return
 			}
-			upstreamReader = bufio.NewReader(proxyConn)
+			s.upstreamReader = bufio.NewReader(s.proxyConn)
 		}
-		injectVia(req.Header, req.Proto, cfg.Pseudonym)
+		injectVia(req.Header, req.Proto, s.cfg.Pseudonym)
 
-		slog.Debug("proxy request", "method", req.Method, "uri", req.RequestURI, "proto", req.Proto, "headers", len(req.Header), "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "via", req.Header.Get(headerVia), "iter", iter)
-		if err := req.WriteProxy(proxyConn); err != nil {
-			slog.Error("failed to write request to proxy", "error", err, "error_type", errConnectionTerminated.errorType, "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "method", req.Method, "host", req.Host)
-			writeHTTPError(conn, errConnectionTerminated)
+		slog.Debug("proxy request", "method", req.Method, "uri", req.RequestURI, "proto", req.Proto, "headers", len(req.Header), "client_addr", s.clientAddr, "upstream_addr", s.cfg.Upstream, "via", req.Header.Get(headerVia), "iter", iter)
+		if err := req.WriteProxy(s.proxyConn); err != nil {
+			slog.Error("failed to write request to proxy", "error", err, "error_type", errConnectionTerminated.errorType, "client_addr", s.clientAddr, "upstream_addr", s.cfg.Upstream, "method", req.Method, "host", req.Host)
+			writeHTTPError(s.conn, errConnectionTerminated)
 			return
 		}
 
-		resp, err := readUpstreamResponse(upstreamReader, req, cfg.Pseudonym)
+		resp, err := readUpstreamResponse(s.upstreamReader, req, s.cfg.Pseudonym)
 		if err != nil {
-			handleUpstreamResponseError(conn, proxyConn, err, clientAddr)
+			handleUpstreamResponseError(s.conn, s.proxyConn, err, s.clientAddr)
 			return
 		}
 
-		writeErr := resp.Write(conn)
+		writeErr := resp.Write(s.conn)
 		if writeErr != nil {
 			_ = resp.Body.Close()
-			logForwardError(writeErr, proxyConn.RemoteAddr(), conn.RemoteAddr())
+			logForwardError(writeErr, s.proxyConn.RemoteAddr(), s.conn.RemoteAddr())
 			return
 		}
 		// Drain any unread body so upstreamReader is aligned for the
@@ -258,7 +260,7 @@ func handleClient(conn net.Conn, cfg Config) {
 		// close the connection instead of continuing the keep-alive loop.
 		if _, derr := io.Copy(io.Discard, resp.Body); derr != nil {
 			_ = resp.Body.Close()
-			slog.Debug("upstream body drain failed, closing connection", "error", derr, "client_addr", clientAddr, "upstream_addr", cfg.Upstream)
+			slog.Debug("upstream body drain failed, closing connection", "error", derr, "client_addr", s.clientAddr, "upstream_addr", s.cfg.Upstream)
 			return
 		}
 		_ = resp.Body.Close()

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -127,6 +127,14 @@ func (s *ClientSession) dialAndAuthUpstream(req *http.Request) net.Conn {
 // non-connection parameters including upstream address, token provider,
 // timeouts, CONNECT port restrictions (D4, RFC 9110 §9.3.6), and
 // forwarding header injection (RFC 7239 Forwarded, X-Forwarded-For, etc.).
+//
+// handleClient is the stable seam called by Serve and the test harness;
+// its signature is deliberately unchanged. It performs the connection-level
+// guards (pseudonym, IP allowlist), owns the conn close / closeWrite and
+// proxyConn cleanup defers (issue #75 LIFO ordering), constructs the
+// per-connection ClientSession, and delegates the request lifecycle to
+// ClientSession.run. All per-connection handlers are methods on
+// ClientSession; cfg is no longer threaded through them individually.
 func handleClient(conn net.Conn, cfg Config) {
 	defer func() { _ = conn.Close() }()
 	// Half-close the write half before the full close so the client

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -227,7 +227,7 @@ func (s *ClientSession) run() {
 		// cannot share with prior HTTP responses on the keep-alive
 		// connection.
 		if req.Method == http.MethodConnect {
-			forwardConnectViaUpstream(s.conn, req, s.reqReader, s.cfg, s.clientAddr)
+			s.tunnelViaUpstream(req)
 			return
 		}
 
@@ -281,28 +281,30 @@ func (s *ClientSession) run() {
 	}
 }
 
-// forwardConnectViaUpstream performs the CONNECT-via-upstream-proxy flow:
+// tunnelViaUpstream performs the CONNECT-via-upstream-proxy flow:
 // inject forwarding headers, acquire a SPNEGO token, dial a FRESH upstream
 // connection, send the CONNECT request, and hand off to handleConnectTunnel.
 // A fresh connection is required because a CONNECT tunnel co-opts the
 // entire upstream connection for opaque bytes; it must not share with
-// prior keep-alive HTTP traffic on the same socket.
-func forwardConnectViaUpstream(conn net.Conn, req *http.Request, reqReader *bufio.Reader, cfg Config, clientAddr string) {
-	injectForwardingHeaders(req, clientAddr, cfg.Forwarding)
+// prior keep-alive HTTP traffic on the same socket. The fresh proxyConn is
+// therefore a method-local connection with its own deferred Close and is
+// never stored on the session (s.proxyConn is the reused keep-alive conn).
+func (s *ClientSession) tunnelViaUpstream(req *http.Request) {
+	injectForwardingHeaders(req, s.clientAddr, s.cfg.Forwarding)
 
-	proxyConn := dialAndAuthUpstream(conn, req, cfg, clientAddr)
+	proxyConn := dialAndAuthUpstream(s.conn, req, s.cfg, s.clientAddr)
 	if proxyConn == nil {
 		return
 	}
 	defer func() { _ = proxyConn.Close() }()
-	injectVia(req.Header, req.Proto, cfg.Pseudonym)
+	injectVia(req.Header, req.Proto, s.cfg.Pseudonym)
 
-	slog.Debug("proxy request", "method", req.Method, "uri", req.RequestURI, "proto", req.Proto, "headers", len(req.Header), "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "via", req.Header.Get(headerVia))
+	slog.Debug("proxy request", "method", req.Method, "uri", req.RequestURI, "proto", req.Proto, "headers", len(req.Header), "client_addr", s.clientAddr, "upstream_addr", s.cfg.Upstream, "via", req.Header.Get(headerVia))
 	if err := req.WriteProxy(proxyConn); err != nil {
-		slog.Error("failed to write request to proxy", "error", err, "error_type", errConnectionTerminated.errorType, "client_addr", clientAddr, "upstream_addr", cfg.Upstream, "method", req.Method, "host", req.Host)
-		writeHTTPError(conn, errConnectionTerminated)
+		slog.Error("failed to write request to proxy", "error", err, "error_type", errConnectionTerminated.errorType, "client_addr", s.clientAddr, "upstream_addr", s.cfg.Upstream, "method", req.Method, "host", req.Host)
+		writeHTTPError(s.conn, errConnectionTerminated)
 		return
 	}
 
-	handleConnectTunnel(conn, proxyConn, reqReader, req, cfg.Pseudonym, clientAddr, cfg.IdleTimeout)
+	handleConnectTunnel(s.conn, proxyConn, s.reqReader, req, s.cfg.Pseudonym, s.clientAddr, s.cfg.IdleTimeout)
 }

--- a/internal/proxy/forward.go
+++ b/internal/proxy/forward.go
@@ -217,7 +217,7 @@ func (s *ClientSession) run() {
 		if matched {
 			slog.Debug("noproxy bypass", "host", req.Host, "pattern", pattern, "method", req.Method, "client_addr", s.clientAddr)
 			if req.Method == http.MethodConnect {
-				handleDirectConnect(s.conn, req, s.reqReader, s.cfg, s.clientAddr)
+				s.tunnelDirect(req)
 			} else {
 				injectVia(req.Header, req.Proto, s.cfg.Pseudonym)
 				handleDirectHTTP(s.conn, req, s.reqReader, s.cfg, s.clientAddr)

--- a/internal/proxy/session.go
+++ b/internal/proxy/session.go
@@ -1,0 +1,40 @@
+package proxy
+
+import (
+	"bufio"
+	"net"
+)
+
+// ClientSession holds the per-connection state for one accepted client
+// connection. Exactly one ClientSession is constructed per handleClient
+// invocation and lives for the duration of that connection.
+//
+// It replaces the previous convention of threading the
+// (conn, cfg, clientAddr) tuple — plus the lazily-dialled upstream
+// connection and its reader — through every per-connection handler as bare
+// parameters. The per-request *http.Request is NOT session state: it varies
+// every keep-alive iteration and stays a method parameter.
+//
+// Ownership rules (enforced by structure, previously by convention):
+//   - conn is owned by handleClient, which retains the close/closeWrite
+//     defers in their original LIFO order (issue #75).
+//   - reqReader is created exactly once over conn and reused on every
+//     keep-alive iteration; recreating it would drop buffered bytes for
+//     pipelined requests.
+//   - proxyConn / upstreamReader are lazily dialled on the first
+//     via-upstream plain-HTTP request and reused on subsequent ones
+//     (RFC 4559 §5); they are closed by the handleClient defer. The
+//     CONNECT-via-upstream and noproxy-direct flows use their own
+//     method-local connections and never touch these fields.
+//   - cfg is a read-only value snapshot, identical to the previous
+//     pass-by-value Config parameter.
+type ClientSession struct {
+	conn       net.Conn
+	cfg        Config
+	clientAddr string
+
+	reqReader *bufio.Reader
+
+	proxyConn      net.Conn
+	upstreamReader *bufio.Reader
+}


### PR DESCRIPTION
## Summary

Resolves #236 — introduces a per-connection `ClientSession` type and converts the per-connection request handlers from free functions (sharing `(conn, req, cfg, clientAddr)` by convention) into methods with domain names. Wide `Config` threading (22 param sites / 42 field reads across 7 functions) collapses to `s.cfg`.

- New `internal/proxy/session.go`: `ClientSession{conn, cfg, clientAddr, reqReader, proxyConn, upstreamReader}`.
- Sub-flows → methods: `run`, `validateRequest`, `dialAndAuthUpstream` (kept its `net.Conn` return so the reused keep-alive conn and the fresh per-CONNECT conn cannot alias), `tunnelViaUpstream`, `tunnelDirect`, `forwardDirect`.
- `handleClient(conn, cfg)` is kept a **frozen seam** (called directly by ~7 test files + `Serve`): the session is constructed *inside* it, cleanup defers stay there (preserves the issue #75 LIFO close ordering).
- `handleConnectTunnel` kept free with its narrow scalar signature; pure helpers kept free.
- Adds repo-root `CONTEXT.md` glossary + `docs/adr/0001` (both mandated by `docs/agents/domain.md`, previously absent).
- Resolves review findings F1 (god-file), F4 (fat `Config`), F8 (generic `handle*` names), F13 (no handling layer).

Zero behaviour change; **not SemVer-relevant** (CLI contract surface untouched) — `refactor:`/`docs:` commits only, no release triggered. Done as 8 substitution-only `refactor:` commits + 1 `docs:` commit, suite green at each step. Diff vs base: only `session.go` (new), `forward.go`, `direct.go`, `CONTEXT.md`, ADR — `connect.go`, `server.go`, and all `*_test.go` are byte-identical.

Fuzz-target gate (issue #236 subtask): **no new target warranted** — no new parseable-input surface; 7 existing leaf-function targets unaffected. Reasoned conclusion recorded on #236 and in ADR-0001.

## Test Plan

- [x] `go test -count=1 ./...` — 476 tests pass
- [x] `golangci-lint run` — 0 issues
- [x] `go vet ./...` — clean
- [x] `go mod tidy` — no go.mod/go.sum diff (no new dependency)
- [x] Acceptance invariant: `git diff <base>..HEAD -- internal/proxy/*_test.go internal/proxy/server.go internal/proxy/connect.go` is empty
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
