### PR TITLE
fix: use compile_native_go_fuzzer_v2 so CFL coverage reports non-zero

### DIFF
--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -21,17 +21,26 @@ GO118_FUZZ_BUILD_VERSION=v0.0.0-20250520111509-a70c2aa677fa
 go install "github.com/AdamKorcz/go-118-fuzz-build@${GO118_FUZZ_BUILD_VERSION}"
 go get "github.com/AdamKorcz/go-118-fuzz-build/testing@${GO118_FUZZ_BUILD_VERSION}"
 
-# compile_native_go_fuzzer imports the target by path; package main is not
+# compile_native_go_fuzzer_v2 imports the target by path; package main is not
 # importable, so the targets live in the internal/proxy package.
 PKG=github.com/andrewesweet/spnego-proxy/internal/proxy
 
-compile_native_go_fuzzer "$PKG" FuzzNoProxyMatch            fuzz_no_proxy_match
-compile_native_go_fuzzer "$PKG" FuzzUpstreamResponseFraming fuzz_upstream_response_framing
-compile_native_go_fuzzer "$PKG" FuzzConnectPortChain        fuzz_connect_port_chain
-compile_native_go_fuzzer "$PKG" FuzzSameHost                fuzz_same_host
-compile_native_go_fuzzer "$PKG" FuzzIPAllowlistChain        fuzz_ip_allowlist_chain
-compile_native_go_fuzzer "$PKG" FuzzContentLengthValues     fuzz_content_length_values
-compile_native_go_fuzzer "$PKG" FuzzHeaderByteValidators    fuzz_header_byte_validators
+# Use the _v2 entrypoint, NOT plain compile_native_go_fuzzer. The v1 script
+# routes coverage builds through build_native_go_fuzzer_legacy, which never
+# writes $OUT/fuzzer_function_names.json (nor native_go_fuzzers.json /
+# fuzzer-parameters.json). The post-#13835 base-runner coverage script reads
+# those files to build `-test.run=^<FuzzFunc>$` and to convert the downloaded
+# corpus to Go's stdlib format; without them every target matched no test
+# ("testing: warning: no tests to run") and reported 0% coverage. The v2
+# entrypoint takes the same args and runs the modern build_native_go_fuzzer,
+# which emits all three files and replays the real corpus during coverage.
+compile_native_go_fuzzer_v2 "$PKG" FuzzNoProxyMatch            fuzz_no_proxy_match
+compile_native_go_fuzzer_v2 "$PKG" FuzzUpstreamResponseFraming fuzz_upstream_response_framing
+compile_native_go_fuzzer_v2 "$PKG" FuzzConnectPortChain        fuzz_connect_port_chain
+compile_native_go_fuzzer_v2 "$PKG" FuzzSameHost                fuzz_same_host
+compile_native_go_fuzzer_v2 "$PKG" FuzzIPAllowlistChain        fuzz_ip_allowlist_chain
+compile_native_go_fuzzer_v2 "$PKG" FuzzContentLengthValues     fuzz_content_length_values
+compile_native_go_fuzzer_v2 "$PKG" FuzzHeaderByteValidators    fuzz_header_byte_validators
 
 # Carry the committed Go regression seed into the ClusterFuzzLite corpus so a
 # fresh storage repo starts from the known FuzzNoProxyMatch reproducer.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,8 +142,10 @@ Key details for AI context:
   storage repo inside the OSS-Fuzz container (no ssh there), so auth is a
   fine-grained PAT scoped to ONLY that repo (contents RW), secret
   `FUZZ_CORPUS_TOKEN` — not an SSH deploy key
-- Register every new `Fuzz*` with a `compile_native_go_fuzzer` line in
-  `.clusterfuzzlite/build.sh`
+- Register every new `Fuzz*` with a `compile_native_go_fuzzer_v2` line in
+  `.clusterfuzzlite/build.sh` (the `_v2` entrypoint, not plain
+  `compile_native_go_fuzzer`: v1 routes coverage through the legacy path that
+  skips the `fuzzer_function_names.json` the runner needs, giving 0% coverage)
 
 ## Release Process
 


### PR DESCRIPTION
## Problem

The nightly ClusterFuzzLite batch **coverage report has been empty (0% across every target) since the first upload on 2026-05-17**. The gh-pages page showed only "Populated by ClusterFuzzLite coverage runs"; `coverage/latest/report/linux/summary.json` reported 0%.

## Root cause

`build.sh` called the v1 `compile_native_go_fuzzer` entrypoint, which routes coverage builds through `build_native_go_fuzzer_legacy`. That path never writes the metadata files the post-#13835 `base-runner/coverage` script relies on:

- `fuzzer_function_names.json`
- `native_go_fuzzers.json`
- `fuzzer-parameters.json`

With `fuzzer_function_names.json` missing, the runner's `get_function_name` returns an error string, so each coverage binary is invoked with `-test.run="^<error>$"`, matches no test (`testing: warning: no tests to run`), and records 0% for every target.

## Fix

Switch to the `_v2` entrypoint (identical args), which runs the modern `build_native_go_fuzzer` and emits all three files. Native-Go-fuzzer coverage is a documented ClusterFuzzLite feature; v1 vs v2 is the undocumented trap.

## Verification (end-to-end)

1. **Local repro** — empty/error `-test.run` name reproduces `no tests to run` / `0.0%`; correct name → non-zero.
2. **Pinned container** (`base-builder-go@sha256:373fb2d9…`, via podman) — v2 build writes all 7 mappings in each JSON; json-driven `-test.run` → `coverage: 6.9%` instead of `no tests to run`.
3. **Production CI** — dispatched `cflite_batch.yml` on this branch (`fuzz_seconds=60`), all jobs green, new `summary.json`:

   | metric | before | after |
   |---|---|---|
   | functions | 0/80 | 15/80 (18.75%) |
   | lines | 0/663 | 133/663 (20.06%) |
   | regions | 0/435 | 105/435 (24.14%) |

   Every per-target log now reports `coverage: X%`; none say `no tests to run`. Nightly 3600s runs will climb higher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)