### PR TITLE
fix: gate FuzzSameHost oracle; keep cflite prune/coverage running on batch finding

### DIFF
--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -63,6 +63,13 @@ jobs:
   prune:
     name: corpus pruning
     needs: batch
+    # Run regardless of whether batch found a bug. run_fuzzers reports a failure
+    # (non-zero exit) on any finding unless dry-run is set, so batch goes red
+    # even though it already uploaded the grown corpus. Corpus pruning and the
+    # coverage upload are orthogonal to "a bug exists" and must not be skipped
+    # by the default failed-dependency behaviour. !cancelled() keeps the bug
+    # signal red while still running here; it skips only on manual cancellation.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Build fuzzers
@@ -87,6 +94,10 @@ jobs:
   coverage:
     name: coverage report
     needs: prune
+    # See prune: run even if batch/prune went red, so the coverage report still
+    # publishes. needs: prune is retained only for ordering (coverage uses the
+    # pruned corpus); !cancelled() detaches it from prune's success/failure.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     steps:
       - name: Build fuzzers (coverage)

--- a/internal/proxy/direct_fuzz_test.go
+++ b/internal/proxy/direct_fuzz_test.go
@@ -27,6 +27,39 @@ func sameHostRef(h, defaultPort string) string {
 	return host + "|" + port
 }
 
+// wellFormedHost reports whether h is a realistic authority: a valid IP literal
+// (optionally bracketed) or a clean DNS-charset name, optionally with a port.
+// The differential below is only sound for such inputs. On malformed bracketing
+// (e.g. "[z:" vs "[[z:]") production's balanced stripIPv6Brackets and
+// sameHostRef's independent TrimPrefix/TrimSuffix legitimately diverge without
+// any two genuinely valid hosts colliding, so asserting there is noise, not a
+// smuggling vector. Mirrors differentiableHost in noproxy_fuzz_test.go.
+func wellFormedHost(h string) bool {
+	h = strings.ToLower(strings.TrimSpace(h))
+	host, _, err := net.SplitHostPort(h)
+	if err != nil {
+		host = h
+		if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+			host = host[1 : len(host)-1]
+		}
+	}
+	if _, e := netip.ParseAddr(host); e == nil {
+		return true
+	}
+	if host == "" {
+		return false
+	}
+	for i := range len(host) {
+		c := host[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '.', c == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
 // FuzzSameHost guards the keep-alive connection binding in handleDirectHTTP:
 // sameHost falsely reporting two different hosts as equal lets a smuggled
 // pipelined request ride a direct connection bound to a different,
@@ -36,9 +69,12 @@ func sameHostRef(h, defaultPort string) string {
 //   - never panics;
 //   - reflexivity: sameHost(a,a,d) is always true;
 //   - symmetry: sameHost(a,b,d) == sameHost(b,a,d);
-//   - one-directional soundness: sameHost(a,b,d)==true implies an independent
-//     canonicalisation also considers them equal. The converse is NOT asserted
-//     (production being stricter than the reference is safe).
+//   - one-directional soundness: for well-formed authorities,
+//     sameHost(a,b,d)==true implies an independent canonicalisation also
+//     considers them equal. The converse is NOT asserted (production being
+//     stricter than the reference is safe), and malformed-bracket inputs are
+//     excluded via wellFormedHost (the two bracket-stripping strategies diverge
+//     there without any valid hosts colliding — noise, not a smuggling vector).
 func FuzzSameHost(f *testing.F) {
 	f.Add("Example.com:80", "example.com", "80")
 	f.Add("[::1]", "[0:0:0:0:0:0:0:1]:80", "80")
@@ -58,7 +94,11 @@ func FuzzSameHost(f *testing.F) {
 		if ab != sameHost(b, a, defaultPort) {
 			t.Fatalf("symmetry violated: a=%q b=%q d=%q", a, b, defaultPort)
 		}
-		if ab && sameHostRef(a, defaultPort) != sameHostRef(b, defaultPort) {
+		// Sound differential, restricted to well-formed authorities: only there
+		// do production's canon and sameHostRef agree on bracket handling, so a
+		// disagreement is a real collision rather than malformed-bracket noise.
+		if ab && wellFormedHost(a) && wellFormedHost(b) &&
+			sameHostRef(a, defaultPort) != sameHostRef(b, defaultPort) {
 			t.Fatalf("sameHost equated different hosts (smuggling vector): a=%q b=%q d=%q ref(a)=%q ref(b)=%q",
 				a, b, defaultPort, sameHostRef(a, defaultPort), sameHostRef(b, defaultPort))
 		}


### PR DESCRIPTION
Two independent commits addressing the failed overnight batch run (#26674458285).

## 1. `fix:` gate FuzzSameHost differential on well-formed hosts

The 3600s batch reported a "smuggling vector" for `a="[z:"` / `b="[[z:]"` — malformed, unbalanced-bracket strings, not valid authorities.

- Production `sameHost` strips only **balanced** `[...]` then re-wraps via `net.JoinHostPort`.
- `sameHostRef` strips brackets **independently** (`TrimPrefix`/`TrimSuffix`).

The two strategies diverge only on malformed brackets, with no two valid hosts colliding → an **unsound oracle false positive**, not a real bug.

Fix: gate the one-directional soundness assertion behind `wellFormedHost` (valid IP literal or clean DNS-charset name), mirroring `differentiableHost` in `noproxy_fuzz_test.go`. No-panic / reflexivity / symmetry stay unconditional. Per CONTRIBUTING.md, the noise reproducer is **not** committed as a seed.

Verified: crash input now passes · `go test ./...` green · 45s native fuzz clean (2.7M execs) · `go mod tidy` no-diff · golangci-lint 0 issues.

## 2. `ci:` run prune and coverage even when batch finds a bug

`run_fuzzers` exits non-zero on any finding unless `dry-run` is set, so the batch job goes red even after uploading the grown corpus. The default failed-dependency behaviour then **skipped** prune and coverage via `needs:`.

Add `if: ${{ !cancelled() }}` to both jobs — they run regardless of batch/prune result; `needs:` retained only for ordering. A genuine finding stays visible (run still red) while corpus maintenance and the coverage upload always complete. `dry-run: true` was rejected: it would silence real bugs too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)