### PR TITLE
ci: scope auto-tag GitHub App token to contents:write

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -98,6 +98,11 @@ jobs:
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # Scope the token down from the app's blanket installation
+          # permissions. The token is only used to check out the repository and
+          # to `git push origin HEAD:master --tags`, both of which are covered
+          # by contents:write.
+          permission-contents: write
 
       - name: Checkout
         # zizmor: ignore[artipacked] credentials are persisted intentionally so the


### PR DESCRIPTION
## Summary

Adds `permission-contents: write` to the `actions/create-github-app-token` step in `.github/workflows/auto-tag.yml`.

Without any `permission-*` input, the minted token inherits the app's **blanket installation permissions**. zizmor's `github-app` audit flags this as a high-confidence finding, which fails the `zizmor` job in **Lint Workflows**.

## Why this is a latent failure on master, not a dependency regression

`zizmorcore/zizmor-action` resolves `GHA_ZIZMOR_VERSION: latest`, so the pinned action SHA does not pin the zizmor binary. The job trips as soon as a zizmor release carrying this audit is published — independent of any bump on our side.

I reproduced this against **unmodified master** with zizmor 1.28.0:

```
error[github-app]: dangerous use of GitHub App tokens
  --> ./.github/workflows/auto-tag.yml:97:15
   = note: audit confidence → High
   = tip: specify at least one `permission-<name>` input to limit the token's permissions
62 findings (4 ignored, 57 suppressed): 0 informational, 0 low, 0 medium, 1 high
```

With this change applied:

```
No findings to report. Good job! (4 ignored, 57 suppressed)
```

It surfaced first on #268 (the pending `github-actions` group bump), which cannot go green until this lands.

## Why `contents: write` is sufficient

The app token is used for exactly two things in this workflow:

1. `actions/checkout` with `token:` — needs `contents: read`
2. `git push origin HEAD:master --tags` — needs `contents: write`

Both are covered by `contents: write`, so narrowing the scope is behaviour-preserving. The job's own `permissions:` block (`checks: read`, `actions: read`) is unchanged and continues to serve the "Verify all CI checks passed" step via `github.token`.

## Fix vs. suppression

`.github/zizmor.yml` documents that intentional exceptions belong in the config rather than inline. This finding is legitimate rather than intentional — the token genuinely was over-scoped — so it is fixed rather than suppressed.

## Versioning

`ci:` — no version bump, per `CLAUDE.md`. No change to the CLI contract surface.

## Test plan

- [x] `zizmor --persona regular .` → no findings (fails with 1 high without the change)
- [ ] `Lint Workflows` green in CI
- [ ] Once merged, rebase #268 and confirm its `zizmor` check passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01DTnmmStFfzByBL7rUFKhxX)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope the GitHub App token in the auto-tag workflow to `contents: write` to remove blanket installation permissions. Passes `zizmor`’s `github-app` audit without changing tagging behavior.

- **Bug Fixes**
  - Add `permission-contents: write` to `actions/create-github-app-token` in `.github/workflows/auto-tag.yml`.
  - Fixes the `zizmor` check in Lint Workflows; token still supports `actions/checkout` and `git push origin HEAD:master --tags`.

<sup>Written for commit dc8aa209484537716944be5af3ca0905ccc2d2cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/andrewesweet/spnego-proxy/pull/269?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

